### PR TITLE
onCallbackFinished Changes

### DIFF
--- a/src/main/java/com/instructure/canvasapi/utilities/APIHelpers.java
+++ b/src/main/java/com/instructure/canvasapi/utilities/APIHelpers.java
@@ -530,7 +530,7 @@ public class APIHelpers {
 
     public static APIStatusDelegate statusDelegateWithContext(final Context context) {
         return new APIStatusDelegate() {
-            @Override public void onCallbackFinished() { }
+            @Override public void onCallbackFinished(CanvasCallback.SOURCE source) { }
 
             @Override
             public Context getContext() {
@@ -539,7 +539,6 @@ public class APIHelpers {
 
             @Override public void onNoNetwork() { }
 
-            @Override public void onCallbackReadFromCache(){}
         };
     }
 

--- a/src/main/java/com/instructure/canvasapi/utilities/APIStatusDelegate.java
+++ b/src/main/java/com/instructure/canvasapi/utilities/APIStatusDelegate.java
@@ -8,8 +8,7 @@ import android.content.Context;
  * Copyright (c) 2014 Instructure. All rights reserved.
  */
 public interface APIStatusDelegate {
-    public void onCallbackFinished();
+    public void onCallbackFinished(CanvasCallback.SOURCE source);
     public void onNoNetwork();
     public Context getContext();
-    public void onCallbackReadFromCache();
 }

--- a/src/main/java/com/instructure/canvasapi/utilities/CanvasCallback.java
+++ b/src/main/java/com/instructure/canvasapi/utilities/CanvasCallback.java
@@ -110,7 +110,7 @@ public abstract class CanvasCallback<T> implements Callback<T> {
 
     private void finishLoading() {
         isFinished = true;
-        statusDelegate.onCallbackFinished();
+        statusDelegate.onCallbackFinished(SOURCE.API);
     }
 
     /**
@@ -163,7 +163,7 @@ public abstract class CanvasCallback<T> implements Callback<T> {
         }
         setHasReadFromCache(true);
         setShouldCache(path);
-        statusDelegate.onCallbackReadFromCache();
+        statusDelegate.onCallbackFinished(SOURCE.CACHE);
     }
 
     public boolean deleteCache(){
@@ -305,6 +305,18 @@ public abstract class CanvasCallback<T> implements Callback<T> {
             errorDelegate.invalidUrlError(retrofitError, getContext());
         } else if (response.getStatus() >= 500 && response.getStatus() < 600) {
             errorDelegate.serverError(retrofitError, getContext());
+        }
+    }
+
+    public static enum SOURCE{
+        API, CACHE;
+
+        public boolean isAPI(){
+            return this == API;
+        }
+
+        public boolean isCache(){
+            return this == CACHE;
         }
     }
 }

--- a/src/main/java/com/instructure/canvasapi/utilities/UserCallback.java
+++ b/src/main/java/com/instructure/canvasapi/utilities/UserCallback.java
@@ -51,7 +51,7 @@ public abstract class UserCallback extends CanvasCallback<User> {
             return;
         }
 
-        statusDelegate.onCallbackFinished();
+        statusDelegate.onCallbackFinished(SOURCE.API);
 
         try {
             APIHelpers.setCacheUser(getContext(), user);


### PR DESCRIPTION
NOTE: These are non -backwards compatible changes.

onCallbackFinished now takes a CanvasCallback.SOURCE object (API, CACHE). onCallbackFinished is now called when data is read from cache, and is passed the source of CACHE   
