### PR TITLE
With Gradle update there is larger support for Lint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ android {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
     }
+    
+    lintOptions {
+        disable 'InvalidPackage'
+    }
 }
 
 //Do some maven stuff


### PR DESCRIPTION
However, it does not work always properly. This will tell Gradle to ignore this error.
