### PR TITLE
Changed an AssignmentGroup's group_weight to use a double instead of a long

### DIFF
--- a/src/main/java/com/instructure/canvasapi/model/AssignmentGroup.java
+++ b/src/main/java/com/instructure/canvasapi/model/AssignmentGroup.java
@@ -16,7 +16,7 @@ public class AssignmentGroup extends CanvasModel<AssignmentGroup> {
 	private long id;
 	private String name;
 	private int position;
-    private long group_weight;
+    private double group_weight;
 	private List<Assignment> assignments = new ArrayList<Assignment>();
 
     ///////////////////////////////////////////////////////////////////////////
@@ -48,8 +48,8 @@ public class AssignmentGroup extends CanvasModel<AssignmentGroup> {
 	public void setAssignments(List<Assignment> assignments) {
 		this.assignments = assignments;
 	}
-    public long getGroupWeight() { return group_weight; }
-    public void setGroupWeight(long group_weight) {this.group_weight = group_weight;}
+    public double getGroupWeight() { return group_weight; }
+    public void setGroupWeight(double group_weight) {this.group_weight = group_weight;}
 
     ///////////////////////////////////////////////////////////////////////////
     // Required Overrides
@@ -77,7 +77,7 @@ public class AssignmentGroup extends CanvasModel<AssignmentGroup> {
         dest.writeString(this.name);
         dest.writeInt(this.position);
         dest.writeList(this.assignments);
-        dest.writeLong(this.group_weight);
+        dest.writeDouble(this.group_weight);
     }
 
     private AssignmentGroup(Parcel in) {
@@ -85,7 +85,7 @@ public class AssignmentGroup extends CanvasModel<AssignmentGroup> {
         this.name = in.readString();
         this.position = in.readInt();
         in.readList(this.assignments, Assignment.class.getClassLoader());
-        this.group_weight = in.readLong();
+        this.group_weight = in.readDouble();
     }
 
     public static Creator<AssignmentGroup> CREATOR = new Creator<AssignmentGroup>() {


### PR DESCRIPTION
group_weights can use decimal places and will error out on retrofit for courses with group_weights
using decimal precision.
