### PR TITLE
Match the reading and writing of parcel

### DIFF
--- a/src/main/java/com/instructure/canvasapi/model/DiscussionTopic.java
+++ b/src/main/java/com/instructure/canvasapi/model/DiscussionTopic.java
@@ -125,6 +125,8 @@ public class DiscussionTopic implements Parcelable, Serializable {
         this.forbidden = in.readByte() != 0;
         in.readList(this.unread_entries, Long.class.getClassLoader());
         in.readList(this.participants, DiscussionParticipant.class.getClassLoader());
+        this.participantsMap = (HashMap<Long, DiscussionParticipant>)in.readSerializable();
+        this.unread_entriesMap = (HashMap<Long, Boolean>)in.readSerializable();
         in.readList(this.view, DiscussionEntry.class.getClassLoader());
     }
 


### PR DESCRIPTION
The reading and writing of discussionTopic didn't match up and
that can cause unmarshalling errors.