### PR TITLE
Fix NPE in DiscussionTopic

### DIFF
--- a/src/main/java/com/instructure/canvasapi/model/DiscussionTopic.java
+++ b/src/main/java/com/instructure/canvasapi/model/DiscussionTopic.java
@@ -30,7 +30,7 @@ public class DiscussionTopic implements Parcelable, Serializable {
     private HashMap<Long, Integer> entry_ratings = new HashMap<>();
 
     //List of all the discussion entries (views)
-    private List<DiscussionEntry> view;
+    private List<DiscussionEntry> view = new ArrayList<>();
 
     ///////////////////////////////////////////////////////////////////////////
     // Getters and Setters


### PR DESCRIPTION
Some users have been getting a null pointer exception when the DiscussionTopic is being created from Parcel.