### PR TITLE
Added ability to receive hashmap of rubric criterion ratings from Sub…

### DIFF
--- a/src/main/java/com/instructure/canvasapi/model/Submission.java
+++ b/src/main/java/com/instructure/canvasapi/model/Submission.java
@@ -210,6 +210,10 @@ public class Submission extends CanvasModel<Submission>{
         return assessment;
     }
 
+    public HashMap<String,RubricCriterionRating> getRubricAssessmentHash(){
+        return this.rubric_assessment;
+    }
+
     public void setRubricAssessment(HashMap<String,RubricCriterionRating> ratings){
         this.rubric_assessment = ratings;
     }


### PR DESCRIPTION
…mission

Currently we have a RubricAssessments object that is generated when getRubricAssessment is called.
This pr adds ability to receive the hashmap that's returned by the server, instead of a RubricAssessment