### PR TITLE
Remove retrofit logging from buildInterface

### DIFF
--- a/src/main/java/com/instructure/canvasapi/api/ConversationAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/ConversationAPI.java
@@ -133,7 +133,6 @@ public class ConversationAPI {
 
     private static ConversationsInterface buildInterface(Context context) {
         RestAdapter restAdapter = CanvasRestAdapter.buildAdapter(context);
-        restAdapter.setLogLevel(RestAdapter.LogLevel.FULL);
         return restAdapter.create(ConversationsInterface.class);
     }
 


### PR DESCRIPTION
Logging code was merged into conversationAPI. This removes it.