### PR TITLE
Going backwards, v23 breaks the galaxy lite and gaurdia. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,11 @@ apply plugin: 'com.android.library'
 
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    compileSdkVersion 22
+    buildToolsVersion '22.0.1'
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 23
+        targetSdkVersion 22
     }
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES'
@@ -52,7 +52,7 @@ android {
         test.setRoot("src/androidTest")
     }
 
-    useLibrary 'org.apache.http.legacy'
+//    useLibrary 'org.apache.http.legacy'
 }
 
 dependencies {


### PR DESCRIPTION
Will stay at v22 until a fix is found. 