### PR TITLE
Update getComparisonString method for AssignmentGroups for speedgrader

### DIFF
--- a/src/main/java/com/instructure/canvasapi/model/AssignmentGroup.java
+++ b/src/main/java/com/instructure/canvasapi/model/AssignmentGroup.java
@@ -62,7 +62,7 @@ public class AssignmentGroup extends CanvasModel<AssignmentGroup> {
 
     @Override
     public String getComparisonString() {
-        return getName();
+        return Integer.toString(position);
     }
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Our canvas app recyclerview ignores the getComparisonString method in lieu of the ItemComparators in our pandarecycler. However speedgrader still uses this
to sort assignmentgroups. Updating this method to sort our expandablelists in SG by the positions returned by canvasAPI rather than the AssignmentGroup names.