### PR TITLE
Updates okHttp to fix FileSystem crashes 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,8 @@ dependencies {
         exclude module: 'stax-api'
         exclude module: 'xpp3'
     }
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.3.0'
-    compile 'com.squareup.okhttp:okhttp:2.3.0'
+    compile 'com.squareup.okhttp:okhttp-urlconnection:2.5.0'
+    compile 'com.squareup.okhttp:okhttp:2.5.0'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
 
     compile group: 'org.apache.httpcomponents' , name: 'httpclient-android' , version: '4.3.5'


### PR DESCRIPTION
Crashes occur in the File System after changes to use okHttp as the caching system. 