### PR TITLE
Fixes some changes that broke PUT and POST with OKHttp after last update.

### DIFF
--- a/src/main/java/com/instructure/canvasapi/api/AssignmentAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/AssignmentAPI.java
@@ -16,15 +16,14 @@ import java.util.List;
 
 import retrofit.Callback;
 import retrofit.RestAdapter;
+import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.PUT;
 import retrofit.http.Path;
 import retrofit.http.Query;
 
 /**
- * Created by Brady Larson on 9/5/13.
- *
- * Copyright (c) 2014 Instructure. All rights reserved.
+ * Copyright (c) 2015 Instructure. All rights reserved.
  */
 public class AssignmentAPI extends BuildInterfaceAPI {
 
@@ -89,6 +88,7 @@ public class AssignmentAPI extends BuildInterfaceAPI {
                             @Query(value = "assignment[url]", encodeValue = false) String url,
                             @Query("assignment[quiz_id]") Long quizId,
                             @Query(value = "assignment[muted]", encodeValue = false) boolean isMuted,
+                            @Body String body,
                             Callback<Assignment> callback);
 
         @GET("/courses/{course_id}/assignments?include[]=submission&include[]=rubric_assessment&needs_grading_count_by_section=true&include[]=all_dates")
@@ -216,7 +216,7 @@ public class AssignmentAPI extends BuildInterfaceAPI {
         Integer newNotifyOfUpdate = APIHelpers.booleanToInt(notifyOfUpdate);
 
         buildInterface(AssignmentsInterface.class, callback, null).editAssignment(assignment.getCourseId(), assignment.getId(), assignmentName, assignmentGroupId, newSubmissionTypes, newHasPeerReviews,
-                                                        groupId, pointsPossible, newGradingType,dueAt,description,newNotifyOfUpdate,unlockAt,lockAt,null, null, null, assignment.isMuted(), callback );
+                                                        groupId, pointsPossible, newGradingType,dueAt,description,newNotifyOfUpdate,unlockAt,lockAt,null, null, null, assignment.isMuted(), "", callback );
 
     }
     public static void editAssignment(Assignment editedAssignment, Boolean notifyOfUpdate, final CanvasCallback<Assignment> callback){
@@ -244,7 +244,7 @@ public class AssignmentAPI extends BuildInterfaceAPI {
         Integer newNotifyOfUpdate = APIHelpers.booleanToInt(notifyOfUpdate);
 
         buildInterface(AssignmentsInterface.class, callback, null).editAssignment(courseId, assignmentId, name, assignmentGroupId, newSubmissionTypes, newHasPeerReviews,
-                groupCategoryId, pointsPossible, newGradingType, stringDueAt, description, newNotifyOfUpdate, stringUnlockAt, stringLockAt, htmlUrl, url, quizId, isMuted, callback);
+                groupCategoryId, pointsPossible, newGradingType, stringDueAt, description, newNotifyOfUpdate, stringUnlockAt, stringLockAt, htmlUrl, url, quizId, isMuted, "", callback);
 
     }
 

--- a/src/main/java/com/instructure/canvasapi/api/AvatarAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/AvatarAPI.java
@@ -8,6 +8,7 @@ import com.instructure.canvasapi.utilities.CanvasRestAdapter;
 
 import retrofit.Callback;
 import retrofit.RestAdapter;
+import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.PUT;
 import retrofit.http.Query;
@@ -23,7 +24,7 @@ public class AvatarAPI extends BuildInterfaceAPI {
         void getFirstPageOfAvatarList( Callback<Avatar[]> callback);
 
         @PUT("/users/self")
-        void updateAvatar(@Query("user[avatar][url]") String avatarURL, Callback<User> callback);
+        void updateAvatar(@Query("user[avatar][url]") String avatarURL, @Body String body, Callback<User> callback);
     }
 
     /////////////////////////////////////////////////////////////////////////
@@ -40,7 +41,7 @@ public class AvatarAPI extends BuildInterfaceAPI {
     public static void updateAvatar(String avatarURL, CanvasCallback<User> callback){
         if(APIHelpers.paramIsNull(callback,avatarURL)){ return; }
 
-        buildInterface(AvatarsInterface.class, callback).updateAvatar(avatarURL, callback);
+        buildInterface(AvatarsInterface.class, callback).updateAvatar(avatarURL, "", callback);
     }
 
 }

--- a/src/main/java/com/instructure/canvasapi/api/BookmarkAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/BookmarkAPI.java
@@ -6,6 +6,7 @@ import com.instructure.canvasapi.utilities.CanvasRestAdapter;
 
 import retrofit.Callback;
 import retrofit.RestAdapter;
+import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.GET;
 import retrofit.http.POST;
@@ -32,6 +33,7 @@ public class BookmarkAPI extends BuildInterfaceAPI {
                 @Query("name") String name,
                 @Query(value = "url", encodeValue = true) String url,
                 @Query("position") int position,
+                @Body String body,
                 Callback<Bookmark> callback);
 
         @PUT("/users/self/bookmarks/{id}")
@@ -39,6 +41,7 @@ public class BookmarkAPI extends BuildInterfaceAPI {
                             @Query("name") String name,
                             @Query(value = "url", encodeValue = false) String url,
                             @Query("position") int position,
+                            @Body String body,
                             Callback<Bookmark> callback);
 
         @DELETE("/users/self/bookmarks/{id}")
@@ -60,7 +63,7 @@ public class BookmarkAPI extends BuildInterfaceAPI {
     }
 
     public static void createBookmark(Bookmark bookmark, CanvasCallback<Bookmark> callback) {
-        buildInterface(BookmarkInterface.class, callback).createBookmark(bookmark.getName(), bookmark.getUrl(), bookmark.getPosition(), callback);
+        buildInterface(BookmarkInterface.class, callback, false).createBookmark(bookmark.getName(), bookmark.getUrl(), bookmark.getPosition(), "", callback);
     }
 
     public static void deleteBookmark(Bookmark bookmark,  CanvasCallback<Bookmark> callback) {
@@ -68,10 +71,10 @@ public class BookmarkAPI extends BuildInterfaceAPI {
     }
 
     public static void deleteBookmark(long bookmarkId, CanvasCallback<Bookmark> callback) {
-        buildInterface(BookmarkInterface.class, callback).deleteBookmark(bookmarkId, callback);
+        buildInterface(BookmarkInterface.class, callback, false).deleteBookmark(bookmarkId, callback);
     }
 
     public static void update(Bookmark bookmark, CanvasCallback<Bookmark> callback) {
-        buildInterface(BookmarkInterface.class, callback).updateBookmark(bookmark.getId(), bookmark.getName(), bookmark.getUrl(), bookmark.getPosition(), callback);
+        buildInterface(BookmarkInterface.class, callback, false).updateBookmark(bookmark.getId(), bookmark.getName(), bookmark.getUrl(), bookmark.getPosition(), "", callback);
     }
 }

--- a/src/main/java/com/instructure/canvasapi/api/CalendarEventAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/CalendarEventAPI.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import retrofit.Callback;
 import retrofit.RestAdapter;
 import retrofit.client.Response;
+import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.EncodedQuery;
 import retrofit.http.GET;
@@ -101,6 +102,7 @@ public class CalendarEventAPI extends BuildInterfaceAPI {
                                  @Query("calendar_event[start_at]") String startDate,
                                  @Query("calendar_event[end_at]") String endDate,
                                  @Query("calendar_event[location_name]") String locationName,
+                                 @Body String body,
                                  CanvasCallback<ScheduleItem> callback);
 
         @DELETE("/calendar_events/{event_id}")
@@ -184,7 +186,7 @@ public class CalendarEventAPI extends BuildInterfaceAPI {
     public static void createCalendarEvent(String contextCode, String title, String description, String startDate, String endDate, String location, final CanvasCallback<ScheduleItem> callback){
         if(APIHelpers.paramIsNull(callback, contextCode) || TextUtils.isEmpty(startDate) || TextUtils.isEmpty(endDate)){return;}
 
-        buildInterface(CalendarEventsInterface.class, callback).createCalendarEvent(contextCode, title, description, startDate, endDate, location, callback);
+        buildInterface(CalendarEventsInterface.class, callback).createCalendarEvent(contextCode, title, description, startDate, endDate, location, "", callback);
     }
 
     public static void deleteCalendarEvent(long calendarEventId, String cancelReason, CanvasCallback<ScheduleItem> callback){

--- a/src/main/java/com/instructure/canvasapi/api/ConversationAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/ConversationAPI.java
@@ -79,25 +79,25 @@ public class ConversationAPI extends BuildInterfaceAPI {
         void deleteConversation(@Path("conversationid")long conversationID, CanvasCallback<Response>responseCallback);
 
         @PUT("/conversations/{conversationid}?conversation[workflow_state]=unread")
-        void markConversationAsUnread(@Path("conversationid")long conversationID, CanvasCallback<Response>responseCallback);
+        void markConversationAsUnread(@Path("conversationid")long conversationID, @Body String body, CanvasCallback<Response>responseCallback);
 
         @PUT("/conversations/{conversationid}?conversation[workflow_state]=archived")
-        void archiveConversation(@Path("conversationid")long conversationID, CanvasCallback<Response>responseCallback);
+        void archiveConversation(@Path("conversationid")long conversationID, @Body String body, CanvasCallback<Response>responseCallback);
 
         @PUT("/conversations/{conversationid}?conversation[workflow_state]=read")
-        void unArchiveConversation(@Path("conversationid")long conversationID, CanvasCallback<Response>responseCallback);
+        void unArchiveConversation(@Path("conversationid")long conversationID, @Body String body, CanvasCallback<Response>responseCallback);
 
         @PUT("/conversations/{conversationid}")
-        void setIsStarred(@Path("conversationid")long conversationID, @Query("conversation[starred]") boolean isStarred, CanvasCallback<Conversation>responseCallback);
+        void setIsStarred(@Path("conversationid")long conversationID, @Query("conversation[starred]") boolean isStarred, @Body String body, CanvasCallback<Conversation>responseCallback);
 
         @PUT("/conversations/{conversationid}")
-        void setIsSubscribed(@Path("conversationid")long conversationID, @Query("conversation[subscribed]") boolean isSubscribed, CanvasCallback<Conversation>responseCallback);
+        void setIsSubscribed(@Path("conversationid")long conversationID, @Query("conversation[subscribed]") boolean isSubscribed, @Body String body, CanvasCallback<Conversation>responseCallback);
 
         @PUT("/conversations/{conversationid}")
-        void setSubject(@Path("conversationid")long conversationID, @Query("conversation[subject]") String subject, CanvasCallback<Conversation>responseCallback);
+        void setSubject(@Path("conversationid")long conversationID, @Query("conversation[subject]") String subject, @Body String body, CanvasCallback<Conversation>responseCallback);
 
         @PUT("/conversations/{conversationid}")
-        void setWorkflowState(@Path("conversationid")long conversationID, @Query("conversation[workflow_state]") String workflowState, CanvasCallback<Conversation>responseCallback);
+        void setWorkflowState(@Path("conversationid")long conversationID, @Query("conversation[workflow_state]") String workflowState, @Body String body, CanvasCallback<Conversation>responseCallback);
 
         /////////////////////////////////////////////////////////////////////////////
         // Synchronous
@@ -177,44 +177,44 @@ public class ConversationAPI extends BuildInterfaceAPI {
     public static void markConversationAsUnread(CanvasCallback<Response>responseCanvasCallback, long conversationId){
         if(APIHelpers.paramIsNull(responseCanvasCallback)){return;}
 
-        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).markConversationAsUnread(conversationId, responseCanvasCallback);
+        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).markConversationAsUnread(conversationId, "", responseCanvasCallback);
     }
 
 
     public static void archiveConversation(CanvasCallback<Response>responseCanvasCallback, long conversationId){
         if(APIHelpers.paramIsNull(responseCanvasCallback)){return;}
 
-        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).archiveConversation(conversationId, responseCanvasCallback);
+        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).archiveConversation(conversationId, "", responseCanvasCallback);
     }
 
     public static void unArchiveConversation(CanvasCallback<Response>responseCanvasCallback, long conversationId){
         if(APIHelpers.paramIsNull(responseCanvasCallback)){return;}
 
-        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).unArchiveConversation(conversationId, responseCanvasCallback);
+        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).unArchiveConversation(conversationId, "", responseCanvasCallback);
     }
 
     public static void subscribeToConversation(long conversationId, boolean isSubscribed, CanvasCallback<Conversation>responseCanvasCallback){
         if(APIHelpers.paramIsNull(responseCanvasCallback)){return;}
 
-        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).setIsSubscribed(conversationId, isSubscribed, responseCanvasCallback);
+        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).setIsSubscribed(conversationId, isSubscribed, "", responseCanvasCallback);
     }
 
     public static void starConversation(long conversationId, boolean isStarred, CanvasCallback<Conversation>responseCanvasCallback){
         if(APIHelpers.paramIsNull(responseCanvasCallback)){return;}
 
-        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).setIsStarred(conversationId, isStarred, responseCanvasCallback);
+        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).setIsStarred(conversationId, isStarred, "", responseCanvasCallback);
     }
 
     public static void setConversationSubject(long conversationId, String newSubject, CanvasCallback<Conversation>responseCanvasCallback){
         if(APIHelpers.paramIsNull(responseCanvasCallback)){return;}
 
-        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).setSubject(conversationId, newSubject, responseCanvasCallback);
+        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).setSubject(conversationId, newSubject, "", responseCanvasCallback);
     }
 
     public static void setConversationWorkflowState(long conversationId, WorkflowState workflowState, CanvasCallback<Conversation>responseCanvasCallback){
         if(APIHelpers.paramIsNull(responseCanvasCallback)){return;}
 
-        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).setWorkflowState(conversationId, conversationStateToString(workflowState), responseCanvasCallback);
+        buildInterface(ConversationsInterface.class, responseCanvasCallback, false).setWorkflowState(conversationId, conversationStateToString(workflowState), "", responseCanvasCallback);
     }
 
     /////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/com/instructure/canvasapi/api/CourseAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/CourseAPI.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import retrofit.RestAdapter;
+import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.GET;
 import retrofit.http.Multipart;
@@ -43,6 +44,7 @@ public class CourseAPI extends BuildInterfaceAPI {
                           @Query("course[name]") String name, @Query("course[course_code]") String courseCode,
                           @Query("course[start_at]") String startAt, @Query("course[end_at]") String endAt,
                           @Query("course[license]") String license, @Query("course[is_public]") Integer isPublic,
+                          @Body String body,
                           CanvasCallback<Course> callback);
 
         @GET("/courses/{courseid}?include[]=term&include[]=permissions&include[]=license&include[]=is_public&include[]=needs_grading_count")
@@ -65,7 +67,7 @@ public class CourseAPI extends BuildInterfaceAPI {
         void getFavoriteCourses(CanvasCallback<Course[]> callback);
 
         @POST("/users/self/favorites/courses/{courseId}")
-        void addCourseToFavorites(@Path("courseId") long courseId, CanvasCallback<Favorite> callback);
+        void addCourseToFavorites(@Path("courseId") long courseId, @Body String body, CanvasCallback<Favorite> callback);
 
         @DELETE("/users/self/favorites/courses/{courseId}")
         void removeCourseFromFavorites(@Path("courseId") long courseId, CanvasCallback<Favorite> callback);
@@ -83,11 +85,11 @@ public class CourseAPI extends BuildInterfaceAPI {
         Course[] getCoursesSynchronous(@Query("page") int page);
 
         @POST("/courses/{courseId}/files")
-        FileUploadParams getFileUploadParams(@Path("courseId") long courseId, @Query("parent_folder_id") Long parentFolderId, @Query("size") long size, @Query("name") String fileName, @Query("content_type") String content_type);
+        FileUploadParams getFileUploadParams(@Path("courseId") long courseId, @Query("parent_folder_id") Long parentFolderId, @Query("size") long size, @Query("name") String fileName, @Query("content_type") String content_type, @Body String body);
 
         @Multipart
         @POST("/")
-        Attachment uploadCourseFile(@PartMap LinkedHashMap<String, String> params, @Part("file") TypedFile file);
+        Attachment uploadCourseFile(@PartMap LinkedHashMap<String, String> params, @Part("file") TypedFile file, @Body String body);
     }
 
     /////////////////////////////////////////////////////////////////////////
@@ -152,7 +154,7 @@ public class CourseAPI extends BuildInterfaceAPI {
     public static void addCourseToFavorites(final long courseId, final CanvasCallback<Favorite> callback) {
         if (APIHelpers.paramIsNull(callback)) return;
 
-        buildInterface(CoursesInterface.class, callback).addCourseToFavorites(courseId, callback);
+        buildInterface(CoursesInterface.class, callback).addCourseToFavorites(courseId, "", callback);
     }
 
     public static void removeCourseFromFavorites(final long courseId, final CanvasCallback<Favorite> callback) {
@@ -229,7 +231,7 @@ public class CourseAPI extends BuildInterfaceAPI {
         String newEndAtString = APIHelpers.dateToString(newEndAt);
         Integer newIsPublicInteger = (newIsPublic == null) ? null : APIHelpers.booleanToInt(newIsPublic);
 
-        buildInterface(CoursesInterface.class, callback).updateCourse(course.getId(), newCourseName, newCourseCode, newStartAtString, newEndAtString, Course.licenseToAPIString(license), newIsPublicInteger, callback);
+        buildInterface(CoursesInterface.class, callback).updateCourse(course.getId(), newCourseName, newCourseCode, newStartAtString, newEndAtString, Course.licenseToAPIString(license), newIsPublicInteger, "", callback);
     }
 
     public static void getCoursesForUser(long userId, CanvasCallback<Course[]> callback) {
@@ -306,10 +308,10 @@ public class CourseAPI extends BuildInterfaceAPI {
     }
 
     public static FileUploadParams getFileUploadParams(Context context, long courseId, Long parentFolderId, String fileName, long size, String contentType){
-        return buildInterface(CoursesInterface.class, context).getFileUploadParams(courseId, parentFolderId, size, fileName, contentType);
+        return buildInterface(CoursesInterface.class, context).getFileUploadParams(courseId, parentFolderId, size, fileName, contentType, "");
     }
 
     public static Attachment uploadCourseFile(Context context, String uploadUrl, LinkedHashMap<String,String> uploadParams, String mimeType, File file){
-        return buildUploadInterface(CoursesInterface.class, uploadUrl).uploadCourseFile(uploadParams, new TypedFile(mimeType, file));
+        return buildUploadInterface(CoursesInterface.class, uploadUrl).uploadCourseFile(uploadParams, new TypedFile(mimeType, file), "");
     }
 }

--- a/src/main/java/com/instructure/canvasapi/api/CustomGradebookColumnAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/CustomGradebookColumnAPI.java
@@ -5,6 +5,7 @@ import com.instructure.canvasapi.model.CustomColumn;
 import com.instructure.canvasapi.utilities.APIHelpers;
 import com.instructure.canvasapi.utilities.CanvasCallback;
 
+import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.POST;
 import retrofit.http.PUT;
@@ -22,13 +23,13 @@ public class CustomGradebookColumnAPI extends BuildInterfaceAPI {
         void getGradebookColumns(@Path("course_id") long courseId, CanvasCallback<CustomColumn[]> callback);
 
         @POST("/courses/{course_id}/custom_gradebook_columns")
-        void createGradebookColumn(@Path("course_id") long courseId, @Query("column[title]") String title, @Query("column[position]") int position, @Query("column[hidden]") boolean isHidden, @Query("column[teacher_notes]") boolean isTeacherNotes, CanvasCallback<CustomColumn> callback);
+        void createGradebookColumn(@Path("course_id") long courseId, @Query("column[title]") String title, @Query("column[position]") int position, @Query("column[hidden]") boolean isHidden, @Query("column[teacher_notes]") boolean isTeacherNotes, @Body String body, CanvasCallback<CustomColumn> callback);
 
         @GET("/courses/{course_id}/custom_gradebook_columns/{column_id}/data")
         void getColumnData(@Path("course_id") long courseId, @Path("column_id") long columnId, CanvasCallback<ColumnDatum[]> callback);
 
         @PUT("/courses/{course_id}/custom_gradebook_columns/{column_id}/data/{user_id}")
-        void updateColumnData(@Path("course_id") long courseId, @Path("column_id") long columnId, @Path("user_id") long user_Id, @Query("column_data[content]") String content, CanvasCallback<ColumnDatum> callback);
+        void updateColumnData(@Path("course_id") long courseId, @Path("column_id") long columnId, @Path("user_id") long user_Id, @Query("column_data[content]") String content, @Body String body, CanvasCallback<ColumnDatum> callback);
     }
 
     /////////////////////////////////////////////////////////////////////////
@@ -45,7 +46,7 @@ public class CustomGradebookColumnAPI extends BuildInterfaceAPI {
     public static void createGradebookColumns(long courseId, String title, int position, boolean isHidden, boolean isTeacherNotes, CanvasCallback<CustomColumn> callback) {
         if (APIHelpers.paramIsNull(callback, title)) { return; }
 
-        buildInterface(CustomGradebookInterface.class, callback).createGradebookColumn(courseId, title, position, isHidden, isTeacherNotes, callback);
+        buildInterface(CustomGradebookInterface.class, callback).createGradebookColumn(courseId, title, position, isHidden, isTeacherNotes, "", callback);
     }
 
     public static void getColumnData(long courseID, long columnId, CanvasCallback<ColumnDatum[]> callback) {
@@ -58,6 +59,6 @@ public class CustomGradebookColumnAPI extends BuildInterfaceAPI {
     public static void updateColumnData(long courseID, long columnId, long userId, String content, CanvasCallback<ColumnDatum> callback) {
         if (APIHelpers.paramIsNull(callback)) { return; }
 
-        buildInterface(CustomGradebookInterface.class, callback).updateColumnData(courseID, columnId, userId, content, callback);
+        buildInterface(CustomGradebookInterface.class, callback).updateColumnData(courseID, columnId, userId, content, "", callback);
     }
 }

--- a/src/main/java/com/instructure/canvasapi/api/DiscussionAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/DiscussionAPI.java
@@ -45,25 +45,25 @@ public class DiscussionAPI extends BuildInterfaceAPI {
         void getFilteredDiscussionTopic(@Path("context_id") long courseId, @Query("search_term") String searchTerm, Callback<DiscussionTopicHeader[]> callback);
 
         @POST("/{context_id}/discussion_topics/{discussionid}/entries/")
-        void postDiscussionEntry(@Path("context_id") long courseId, @Path("discussionid") long discussionId, @Query("message") String message, Callback<DiscussionEntry> callback);
+        void postDiscussionEntry(@Path("context_id") long courseId, @Path("discussionid") long discussionId, @Query("message") String message, @Body String body, Callback<DiscussionEntry> callback);
 
         @POST("/{context_id}/discussion_topics/{discussionid}/entries/{entryid}/replies")
-        void postDiscussionReply(@Path("context_id") long courseId, @Path("discussionid") long discussionId, @Path("entryid") long entryId, @Query("message")String message, Callback<DiscussionEntry> callback);
+        void postDiscussionReply(@Path("context_id") long courseId, @Path("discussionid") long discussionId, @Path("entryid") long entryId, @Query("message")String message, @Body String body, Callback<DiscussionEntry> callback);
 
         @POST("/{context_id}/discussion_topics/")
-        void postNewDiscussion(@Path("context_id")long courseId, @Query("title") String title, @Query("message")String message, @Query("is_announcement")int announcement, @Query("discussion_type")String discussion_type, Callback<DiscussionTopicHeader> callback);
+        void postNewDiscussion(@Path("context_id")long courseId, @Query("title") String title, @Query("message")String message, @Query("is_announcement")int announcement, @Query("discussion_type")String discussion_type, @Body String body, Callback<DiscussionTopicHeader> callback);
 
         @POST("/{context_id}/discussion_topics/")
-        void postNewDiscussionAndPublish(@Path("context_id")long courseId, @Query("title") String title, @Query("message")String message, @Query("is_announcement")int announcement, @Query("published") int isPublished, @Query("discussion_type")String discussion_type, Callback<DiscussionTopicHeader> callback);
+        void postNewDiscussionAndPublish(@Path("context_id")long courseId, @Query("title") String title, @Query("message")String message, @Query("is_announcement")int announcement, @Query("published") int isPublished, @Query("discussion_type")String discussion_type, @Body String body, Callback<DiscussionTopicHeader> callback);
 
         @PUT("/{context_id}/discussion_topics/{topic_id}")
-        void updateDiscussionTopic(@Path("context_id") long courseId, @Path("topic_id") long topicId, @Query("title") String title, @Query("message")String message, @Query("published") int isPublished, @Query("discussion_type")String discussion_type, Callback<DiscussionTopicHeader> callback);
+        void updateDiscussionTopic(@Path("context_id") long courseId, @Path("topic_id") long topicId, @Query("title") String title, @Query("message")String message, @Query("published") int isPublished, @Query("discussion_type")String discussion_type, @Body String body, Callback<DiscussionTopicHeader> callback);
 
         @POST("/{context_id}/discussion_topics/{discussionId}/entries/{entryId}/rating")
-        void rateDiscussionEntry(@Path("context_id") long courseId, @Path("discussionId") long discussionId, @Path("entryId") long entryId, @Query("rating") int rating, Callback<Response> callback);
+        void rateDiscussionEntry(@Path("context_id") long courseId, @Path("discussionId") long discussionId, @Path("entryId") long entryId, @Query("rating") int rating, @Body String body, Callback<Response> callback);
 
         @PUT("/{context_id}/discussion_topics/{topic_id}")
-        void pinDiscussion(@Path("context_id") long courseId, @Path("topic_id") long discussionId, @Query("pinned") boolean pinned, Callback<DiscussionTopicHeader> callback);
+        void pinDiscussion(@Path("context_id") long courseId, @Path("topic_id") long discussionId, @Query("pinned") boolean pinned, @Body String body, Callback<DiscussionTopicHeader> callback);
 
     }
 
@@ -181,13 +181,13 @@ public class DiscussionAPI extends BuildInterfaceAPI {
     public static void postDiscussionEntry(CanvasContext canvasContext, long discussionId, String message, CanvasCallback<DiscussionEntry> callback){
         if (APIHelpers.paramIsNull(callback, message, canvasContext)) { return; }
 
-        buildInterface(DiscussionsInterface.class, callback, canvasContext).postDiscussionEntry(canvasContext.getId(), discussionId, message, callback);
+        buildInterface(DiscussionsInterface.class, callback, canvasContext).postDiscussionEntry(canvasContext.getId(), discussionId, message, "", callback);
     }
 
     public static void postDiscussionReply(CanvasContext canvasContext, long discussionId, long entryId, String message, CanvasCallback<DiscussionEntry> callback){
         if (APIHelpers.paramIsNull(callback, message, canvasContext)) { return; }
 
-        buildInterface(DiscussionsInterface.class, callback, canvasContext).postDiscussionReply(canvasContext.getId(), discussionId, entryId, message, callback);
+        buildInterface(DiscussionsInterface.class, callback, canvasContext).postDiscussionReply(canvasContext.getId(), discussionId, entryId, message, "", callback);
     }
 
     public static void postNewDiscussion(CanvasContext canvasContext, String  title, String message, boolean threaded, boolean is_announcement, CanvasCallback<DiscussionTopicHeader> callback){
@@ -202,7 +202,7 @@ public class DiscussionAPI extends BuildInterfaceAPI {
 
         int announcement = APIHelpers.booleanToInt(is_announcement);
 
-        buildInterface(DiscussionsInterface.class, callback, canvasContext).postNewDiscussion(canvasContext.getId(), title, message, announcement, type, callback);
+        buildInterface(DiscussionsInterface.class, callback, canvasContext).postNewDiscussion(canvasContext.getId(), title, message, announcement, type, "", callback);
     }
 
     public static void postNewDiscussionAndPublish(CanvasContext canvasContext, String  title, String message, boolean threaded, boolean is_announcement, boolean isPublished, CanvasCallback<DiscussionTopicHeader> callback){
@@ -218,7 +218,7 @@ public class DiscussionAPI extends BuildInterfaceAPI {
         int announcement = APIHelpers.booleanToInt(is_announcement);
         int publish = APIHelpers.booleanToInt(isPublished);
 
-        buildInterface(DiscussionsInterface.class, callback, canvasContext).postNewDiscussionAndPublish(canvasContext.getId(), title, message, announcement, publish, type, callback);
+        buildInterface(DiscussionsInterface.class, callback, canvasContext).postNewDiscussionAndPublish(canvasContext.getId(), title, message, announcement, publish, type, "", callback);
     }
 
     public static void updateDiscussionTopic(CanvasContext canvasContext, long topicId, String  title, String message, boolean threaded, boolean isPublished, CanvasCallback<DiscussionTopicHeader> callback){
@@ -232,7 +232,7 @@ public class DiscussionAPI extends BuildInterfaceAPI {
 
         int publish = APIHelpers.booleanToInt(isPublished);
 
-        buildInterface(DiscussionsInterface.class, callback, canvasContext).updateDiscussionTopic(canvasContext.getId(), topicId, title, message, publish, type, callback);
+        buildInterface(DiscussionsInterface.class, callback, canvasContext).updateDiscussionTopic(canvasContext.getId(), topicId, title, message, publish, type, "", callback);
 
     }
 
@@ -242,7 +242,7 @@ public class DiscussionAPI extends BuildInterfaceAPI {
     public static void rateDiscussionEntry(CanvasContext canvasContext, long discussionId, long entryId, int rating, CanvasCallback<Response> callback){
         if (APIHelpers.paramIsNull(callback, canvasContext)) { return; }
 
-        buildInterface(DiscussionsInterface.class, callback, canvasContext).rateDiscussionEntry(canvasContext.getId(), discussionId, entryId, rating, callback);
+        buildInterface(DiscussionsInterface.class, callback, canvasContext).rateDiscussionEntry(canvasContext.getId(), discussionId, entryId, rating, "", callback);
     }
 
     /**
@@ -255,6 +255,6 @@ public class DiscussionAPI extends BuildInterfaceAPI {
     public static void pinDiscussion(CanvasContext canvasContext, long topicId, boolean pin, CanvasCallback<DiscussionTopicHeader> callback) {
         if (APIHelpers.paramIsNull(callback, canvasContext)) { return; }
 
-        buildInterface(DiscussionsInterface.class, callback, canvasContext).pinDiscussion(canvasContext.getId(), topicId, pin, callback);
+        buildInterface(DiscussionsInterface.class, callback, canvasContext).pinDiscussion(canvasContext.getId(), topicId, pin, "", callback);
     }
 }

--- a/src/main/java/com/instructure/canvasapi/api/ErrorReportAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/ErrorReportAPI.java
@@ -6,6 +6,7 @@ import com.instructure.canvasapi.utilities.CanvasCallback;
 import com.instructure.canvasapi.utilities.CanvasRestAdapter;
 
 import retrofit.RestAdapter;
+import retrofit.http.Body;
 import retrofit.http.POST;
 import retrofit.http.Query;
 
@@ -16,7 +17,7 @@ public class ErrorReportAPI {
 
     public interface ErrorReportInterface {
         @POST("/error_reports.json")
-        void postErrorReport(@Query("error[subject]") String subject, @Query("error[url]") String url, @Query("error[email]") String email, @Query("error[comments]") String comments, @Query("error[user_perceived_severity") String userPerceivedSeverity, CanvasCallback<ErrorReportResult> callback);
+        void postErrorReport(@Query("error[subject]") String subject, @Query("error[url]") String url, @Query("error[email]") String email, @Query("error[comments]") String comments, @Query("error[user_perceived_severity") String userPerceivedSeverity, @Body String body, CanvasCallback<ErrorReportResult> callback);
     }
 
     /////////////////////////////////////////////////////////////////////////
@@ -34,6 +35,6 @@ public class ErrorReportAPI {
     public static void postErrorReport(String subject, String url, String email, String comments, String userPerceivedSeverity, CanvasCallback<ErrorReportResult> callback) {
         if(APIHelpers.paramIsNull(callback, subject, url, email, comments, userPerceivedSeverity)) return;
 
-        buildInterface(callback).postErrorReport(subject, url, email, comments, userPerceivedSeverity, callback);
+        buildInterface(callback).postErrorReport(subject, url, email, comments, userPerceivedSeverity, "", callback);
     }
 }

--- a/src/main/java/com/instructure/canvasapi/api/GroupAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/GroupAPI.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import retrofit.client.Response;
+import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.GET;
 import retrofit.http.POST;
@@ -49,22 +50,22 @@ public class GroupAPI extends BuildInterfaceAPI {
         void getNextPageGroupUsers(@Path(value = "next", encode = false) String nextURL, CanvasCallback<User[]> callback);
 
         @POST("/groups?[]=favorites")
-        void createGroup(@Query("name") String name, @Query("is_public") boolean isPublic, CanvasCallback<Group> callback);
+        void createGroup(@Query("name") String name, @Query("is_public") boolean isPublic, @Body String body, CanvasCallback<Group> callback);
 
         @DELETE("/groups/{groupid}")
         void deleteGroup(@Path("groupid") long groupId, CanvasCallback<Response> callback);
 
         @POST("/groups/{groupid}/memberships")
-        void createMembership(@Path("groupid") long groupId, @Query("user_id") String userId, CanvasCallback<Response> callback);
+        void createMembership(@Path("groupid") long groupId, @Query("user_id") String userId, @Body String body, CanvasCallback<Response> callback);
 
         @POST("/group_categories/{group_category_id}/groups")
-        void createGroupWithCategory(@Path("group_category_id") long groupCategoryId, @Query("name") String name, @Query("is_public") boolean isPublic, CanvasCallback<Group> callback);
+        void createGroupWithCategory(@Path("group_category_id") long groupCategoryId, @Query("name") String name, @Query("is_public") boolean isPublic, @Body String body, CanvasCallback<Group> callback);
 
         @GET("/users/self/favorites/groups?[]=favorites")
         void getFavoriteGroups(CanvasCallback<Group[]> callback);
 
         @POST("/users/self/favorites/groups/{groupId}")
-        void addGroupToFavorites(@Path("groupId") long groupId, CanvasCallback<Favorite> callback);
+        void addGroupToFavorites(@Path("groupId") long groupId, @Body String body, CanvasCallback<Favorite> callback);
 
         @DELETE("/users/self/favorites/groups/{groupId}")
         void removeGroupFromFavorites(@Path("groupId") long groupId, CanvasCallback<Favorite> callback);
@@ -199,13 +200,13 @@ public class GroupAPI extends BuildInterfaceAPI {
     public static void createGroup(String name, boolean isPublic, CanvasCallback<Group> callback) {
         if (APIHelpers.paramIsNull(name, callback)) return;
 
-        buildInterface(GroupsInterface.class, callback).createGroup(name, isPublic, callback);
+        buildInterface(GroupsInterface.class, callback).createGroup(name, isPublic, "", callback);
     }
 
     public static void createGroupWithCategory(long categoryId, String name, boolean isPublic, CanvasCallback<Group> callback) {
         if (APIHelpers.paramIsNull(name, callback)) return;
 
-        buildInterface(GroupsInterface.class, callback).createGroupWithCategory(categoryId, name, isPublic, callback);
+        buildInterface(GroupsInterface.class, callback).createGroupWithCategory(categoryId, name, isPublic, "", callback);
     }
 
     public static void deleteGroup(long groupId, CanvasCallback<Response>responseCanvasCallback){
@@ -217,13 +218,13 @@ public class GroupAPI extends BuildInterfaceAPI {
     public static void createMembership(long groupId, String userId, CanvasCallback<Response> callback) {
         if (APIHelpers.paramIsNull(userId, callback)) return;
 
-        buildInterface(GroupsInterface.class, callback).createMembership(groupId, userId, callback);
+        buildInterface(GroupsInterface.class, callback).createMembership(groupId, userId, "", callback);
     }
 
     public static void addGroupToFavorites(final long groupId, final CanvasCallback<Favorite> callback) {
         if (APIHelpers.paramIsNull(callback)) return;
 
-        buildInterface(GroupsInterface.class, callback).addGroupToFavorites(groupId, callback);
+        buildInterface(GroupsInterface.class, callback).addGroupToFavorites(groupId, "", callback);
     }
 
     public static void removeGroupFromFavorites(final long groupId, final CanvasCallback<Favorite> callback) {

--- a/src/main/java/com/instructure/canvasapi/api/GroupCategoriesAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/GroupCategoriesAPI.java
@@ -7,6 +7,7 @@ import com.instructure.canvasapi.utilities.APIHelpers;
 import com.instructure.canvasapi.utilities.CanvasCallback;
 
 import retrofit.Callback;
+import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.POST;
 import retrofit.http.Path;
@@ -30,7 +31,7 @@ public class GroupCategoriesAPI extends BuildInterfaceAPI {
         void getNextPageGroupCategories(@Path(value = "next", encode = false) String nextURL, Callback<GroupCategory[]> callback);
 
         @POST("/courses/{course_id}/group_categories")
-        void createGroupCategoryForCourse(@Path("course_id") long courseId, @Query("name") String name, CanvasCallback<GroupCategory> callback);
+        void createGroupCategoryForCourse(@Path("course_id") long courseId, @Query("name") String name, @Body String body, CanvasCallback<GroupCategory> callback);
 
         @GET("/group_categories/{group_category_id}/groups")
         void getFirstPageGroupsFromCategory(@Path("group_category_id") long groupCategoryId, CanvasCallback<Group[]> callback);
@@ -56,7 +57,7 @@ public class GroupCategoriesAPI extends BuildInterfaceAPI {
     public static void createGroupCategoryForCourse(long courseId, String name, CanvasCallback<GroupCategory> callback) {
         if(APIHelpers.paramIsNull(name, callback)) return;
 
-        buildInterface(GroupCategoriesInterface.class, callback).createGroupCategoryForCourse(courseId, name, callback);
+        buildInterface(GroupCategoriesInterface.class, callback).createGroupCategoryForCourse(courseId, name, "", callback);
     }
 
     public static void getFirstPageGroupCategoriesInCourse(long courseId, CanvasCallback<GroupCategory[]> callback) {

--- a/src/main/java/com/instructure/canvasapi/api/KalturaAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/KalturaAPI.java
@@ -27,13 +27,14 @@ import java.io.File;
 
 import retrofit.Callback;
 import retrofit.RestAdapter;
+import retrofit.http.Body;
 import retrofit.http.EncodedQuery;
 import retrofit.http.GET;
 import retrofit.http.POST;
 import retrofit.http.Query;
 
 /**
- * Copyright (c) 2014 Instructure. All rights reserved.
+ * Copyright (c) 2015 Instructure. All rights reserved.
  */
 
 //Make caching work
@@ -48,7 +49,7 @@ public class KalturaAPI extends BuildInterfaceAPI {
         void getKalturaConfigaration(Callback<KalturaConfig> callback);
 
         @POST("/services/kaltura_session")
-        void startKalturaSession(Callback<KalturaSession> callback);
+        void startKalturaSession(@Body String body, Callback<KalturaSession> callback);
 
     }
     
@@ -56,11 +57,11 @@ public class KalturaAPI extends BuildInterfaceAPI {
     public interface KalturaAPIInterface {
 
         @POST("/index.php?service=uploadtoken&action=add")
-        void getKalturaUploadToken(@EncodedQuery("ks") String ks, Callback<xml> callback);
+        void getKalturaUploadToken(@Query(value = "ks", encodeValue = true) String ks, @Body String body, Callback<xml> callback);
 
 
         @POST("/index.php?service=media&action=addFromUploadedFile")
-        xml getMediaIdForUploadedFileTokenSynchronous(@Query("ks") String ks, @Query("uploadTokenId") String uploadToken, @Query("mediaEntry:name") String name, @Query("mediaEntry:mediaType") String mediaType);
+        xml getMediaIdForUploadedFileTokenSynchronous(@Query("ks") String ks, @Query("uploadTokenId") String uploadToken, @Query("mediaEntry:name") String name, @Query("mediaEntry:mediaType") String mediaType, @Body String body);
 
     }
 
@@ -89,7 +90,7 @@ public class KalturaAPI extends BuildInterfaceAPI {
             return;
         }
 
-        buildInterface(KalturaConfigurationInterface.class, callback, null).startKalturaSession(callback);
+        buildInterface(KalturaConfigurationInterface.class, callback, null).startKalturaSession("", callback);
     }
 
     public static void getKalturaUploadToken(final CanvasCallback<xml> callback) {
@@ -99,7 +100,7 @@ public class KalturaAPI extends BuildInterfaceAPI {
 
         String kalturaToken = APIHelpers.getKalturaToken(callback.getContext());
 
-        buildKalturaAPIInterface(callback).getKalturaUploadToken(kalturaToken, callback);
+        buildKalturaAPIInterface(callback).getKalturaUploadToken(kalturaToken, "", callback);
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -161,7 +162,7 @@ public class KalturaAPI extends BuildInterfaceAPI {
         try {
             RestAdapter restAdapter = KalturaRestAdapter.buildAdapter(context);
             String mediaTypeConverted = FileUtilities.kalturaCodeFromMimeType(mimetype); 
-            return restAdapter.create(KalturaAPIInterface.class).getMediaIdForUploadedFileTokenSynchronous(ks, uploadToken, fileName, mediaTypeConverted);
+            return restAdapter.create(KalturaAPIInterface.class).getMediaIdForUploadedFileTokenSynchronous(ks, uploadToken, fileName, mediaTypeConverted, "");
         } catch (Exception E) {
             Log.e(APIHelpers.LOG_TAG, E.toString());
             return null;

--- a/src/main/java/com/instructure/canvasapi/api/ModuleAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/ModuleAPI.java
@@ -8,6 +8,7 @@ import com.instructure.canvasapi.utilities.CanvasCallback;
 import com.squareup.okhttp.Response;
 
 import retrofit.Callback;
+import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.POST;
 import retrofit.http.Path;
@@ -32,7 +33,7 @@ public class ModuleAPI extends BuildInterfaceAPI {
         void getNextPageModuleItemList(@Path(value = "next", encode = false) String nextURL, Callback<ModuleItem[]> callback);
 
         @POST("/{context_id}/modules/{moduleid}/items/{itemid}/mark_read")
-        void markModuleItemRead(@Path("context_id") long context_id, @Path("moduleid") long module_id, @Path("itemid") long item_id, Callback<Response> callback);
+        void markModuleItemRead(@Path("context_id") long context_id, @Path("moduleid") long module_id, @Path("itemid") long item_id, @Body String body, Callback<Response> callback);
     }
 
     /////////////////////////////////////////////////////////////////////////
@@ -85,6 +86,6 @@ public class ModuleAPI extends BuildInterfaceAPI {
             return;
         }
 
-        buildInterface(ModulesInterface.class, callback, canvasContext).markModuleItemRead(canvasContext.getId(), moduleId, itemId, callback);
+        buildInterface(ModulesInterface.class, callback, canvasContext).markModuleItemRead(canvasContext.getId(), moduleId, itemId, "", callback);
     }
 }

--- a/src/main/java/com/instructure/canvasapi/api/NotificationPreferencesAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/NotificationPreferencesAPI.java
@@ -37,16 +37,16 @@ public class NotificationPreferencesAPI extends BuildInterfaceAPI {
         void getSingleNotificationPreferencesForType(@Path("user_id") long userId, @Path("type") String type, @Path("address") String address, @Path("notification") String notification, CanvasCallback<NotificationPreferenceResponse> callback);
 
         @PUT("/users/self/communication_channels/{communication_channel_id}/notification_preferences/{notification}")
-        void updateSingleNotificationPreference(@Path("communication_channel_id") long communicationChannelId, @Path("notification") String notification, CanvasCallback<NotificationPreferenceResponse> callback);
+        void updateSingleNotificationPreference(@Path("communication_channel_id") long communicationChannelId, @Path("notification") String notification, @Body String body, CanvasCallback<NotificationPreferenceResponse> callback);
 
         @PUT("/users/self/communication_channels/{type}/{address}/notification_preferences/{notification}")
-        void updateSingleNotificationPreferenceForType(@Path("type") String type, @Path("address") String address, @Path("notification") String notification, CanvasCallback<NotificationPreferenceResponse> callback);
+        void updateSingleNotificationPreferenceForType(@Path("type") String type, @Path("address") String address, @Path("notification") String notification, @Body String body, CanvasCallback<NotificationPreferenceResponse> callback);
 
         @PUT("/users/self/communication_channels/{type}/{address}/notification_preferences{notification_preferences}")
-        void updateMultipleNotificationPreferencesForType(@Path("type") String type, @Path("address") String address, @Path(value = "notification_preferences", encode = false) String notifications, CanvasCallback<NotificationPreferenceResponse> callback);
+        void updateMultipleNotificationPreferencesForType(@Path("type") String type, @Path("address") String address, @Path(value = "notification_preferences", encode = false) String notifications, @Body String body, CanvasCallback<NotificationPreferenceResponse> callback);
 
         @PUT("/users/self/communication_channels/{communication_channel_id}/notification_preferences{notification_preferences}")
-        void updateMultipleNotificationPreferences(@Path("communication_channel_id") long communicationChannelId, @Path(value = "notification_preferences", encode = false) String notifications, CanvasCallback<NotificationPreferenceResponse> callback);
+        void updateMultipleNotificationPreferences(@Path("communication_channel_id") long communicationChannelId, @Path(value = "notification_preferences", encode = false) String notifications, @Body String body, CanvasCallback<NotificationPreferenceResponse> callback);
 
         @PUT("/users/self/communication_channels/{communication_channel_id}/notification_preferences")
         void updateMultipleNotificationPreferences(@Path("communication_channel_id") long communicationChannelId, @Body NotificationPreferenceResponse preferencesToChange, CanvasCallback<NotificationPreferenceResponse> callback);
@@ -83,25 +83,25 @@ public class NotificationPreferencesAPI extends BuildInterfaceAPI {
     public static void updateSingleNotificationPreference(final long communicationChannelId, final String notification, final CanvasCallback<NotificationPreferenceResponse> callback) {
         if (APIHelpers.paramIsNull(callback)) { return; }
 
-        buildInterface(NotificationPreferencesInterface.class, callback, null, false).updateSingleNotificationPreference(communicationChannelId, notification, callback);
+        buildInterface(NotificationPreferencesInterface.class, callback, null, false).updateSingleNotificationPreference(communicationChannelId, notification, "", callback);
     }
 
     public static void updateSingleNotificationPreferenceForType(final String type, final String address, final String notification, final CanvasCallback<NotificationPreferenceResponse> callback) {
         if (APIHelpers.paramIsNull(callback)) { return; }
 
-        buildInterface(NotificationPreferencesInterface.class, callback, null, false).updateSingleNotificationPreferenceForType(type, address, notification, callback);
+        buildInterface(NotificationPreferencesInterface.class, callback, null, false).updateSingleNotificationPreferenceForType(type, address, notification, "", callback);
     }
 
     public static void updateMultipleNotificationPreferencesForType(final String type, final String address, final ArrayList<String> notifications, final String frequency, final CanvasCallback<NotificationPreferenceResponse> callback) {
         if (APIHelpers.paramIsNull(callback)) { return; }
 
-        buildInterface(NotificationPreferencesInterface.class, callback, null, false).updateMultipleNotificationPreferencesForType(type, address, buildNotificationPreferenceList(notifications, frequency), callback);
+        buildInterface(NotificationPreferencesInterface.class, callback, null, false).updateMultipleNotificationPreferencesForType(type, address, buildNotificationPreferenceList(notifications, frequency), "", callback);
     }
 
     public static void updateMultipleNotificationPreferences(final long communicationChannelId, final ArrayList<String> notifications, final String frequency, final CanvasCallback<NotificationPreferenceResponse> callback) {
         if (APIHelpers.paramIsNull(callback, notifications, frequency)) { return; }
 
-        buildInterface(NotificationPreferencesInterface.class, callback, null, false).updateMultipleNotificationPreferences(communicationChannelId, buildNotificationPreferenceList(notifications, frequency), callback);
+        buildInterface(NotificationPreferencesInterface.class, callback, null, false).updateMultipleNotificationPreferences(communicationChannelId, buildNotificationPreferenceList(notifications, frequency), "", callback);
     }
 
     /**

--- a/src/main/java/com/instructure/canvasapi/api/PollAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/PollAPI.java
@@ -6,6 +6,7 @@ import com.instructure.canvasapi.utilities.CanvasCallback;
 
 import retrofit.Callback;
 import retrofit.client.Response;
+import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.GET;
 import retrofit.http.POST;
@@ -30,10 +31,10 @@ public class PollAPI extends BuildInterfaceAPI {
         void getSinglePoll(@Path("pollid") long poll_id, Callback<PollResponse> callback);
 
         @POST("/polls")
-        void createPoll(@Query("polls[][question]") String pollTitle, Callback<PollResponse> callback);
+        void createPoll(@Query("polls[][question]") String pollTitle, @Body String body, Callback<PollResponse> callback);
 
         @PUT("/polls/{pollid}")
-        void updatePoll(@Path("pollid") long poll_id, @Query("polls[][question]") String pollTitle, Callback<PollResponse> callback);
+        void updatePoll(@Path("pollid") long poll_id, @Query("polls[][question]") String pollTitle, @Body String body, Callback<PollResponse> callback);
 
         @DELETE("/polls/{pollid}")
         void deletePoll(@Path("pollid") long poll_id, Callback<Response> callback);
@@ -68,13 +69,13 @@ public class PollAPI extends BuildInterfaceAPI {
     public static void createPoll(String title, CanvasCallback<PollResponse> callback) {
         if (APIHelpers.paramIsNull(callback, title)) { return; }
 
-        buildInterface(PollInterface.class, callback).createPoll(title, callback);
+        buildInterface(PollInterface.class, callback).createPoll(title, "", callback);
     }
 
     public static void updatePoll(long poll_id, String title, CanvasCallback<PollResponse> callback) {
         if (APIHelpers.paramIsNull(callback, poll_id, title)) { return; }
 
-        buildInterface(PollInterface.class, callback).updatePoll(poll_id, title, callback);
+        buildInterface(PollInterface.class, callback).updatePoll(poll_id, title, "", callback);
     }
 
     public static void deletePoll(long poll_id, CanvasCallback<Response> callback) {

--- a/src/main/java/com/instructure/canvasapi/api/PollChoiceAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/PollChoiceAPI.java
@@ -6,6 +6,7 @@ import com.instructure.canvasapi.utilities.CanvasCallback;
 
 import retrofit.Callback;
 import retrofit.client.Response;
+import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.GET;
 import retrofit.http.POST;
@@ -30,10 +31,10 @@ public class PollChoiceAPI extends BuildInterfaceAPI {
         void getSinglePollChoice(@Path("pollid") long poll_id, @Path("poll_choice_id") long poll_choice_id, Callback<PollChoiceResponse> callback);
 
         @POST("/polls/{pollid}/poll_choices")
-        void createPollChoice(@Path("pollid") long poll_id, @Query("poll_choices[][text]") String pollChoiceText, @Query("poll_choices[][is_correct]") boolean isCorrect, @Query("poll_choices[][position]") int position, Callback<PollChoiceResponse> callback);
+        void createPollChoice(@Path("pollid") long poll_id, @Query("poll_choices[][text]") String pollChoiceText, @Query("poll_choices[][is_correct]") boolean isCorrect, @Query("poll_choices[][position]") int position, @Body String body, Callback<PollChoiceResponse> callback);
 
         @PUT("/polls/{pollid}/poll_choices/{poll_choice_id}")
-        void updatePollChoice(@Path("pollid") long poll_id, @Path("poll_choice_id") long poll_choice_id, @Query("poll_choices[][text]") String pollChoiceText, @Query("poll_choices[][is_correct]") boolean isCorrect, @Query("poll_choices[][position]") int position, Callback<PollChoiceResponse> callback);
+        void updatePollChoice(@Path("pollid") long poll_id, @Path("poll_choice_id") long poll_choice_id, @Query("poll_choices[][text]") String pollChoiceText, @Query("poll_choices[][is_correct]") boolean isCorrect, @Query("poll_choices[][position]") int position, @Body String body, Callback<PollChoiceResponse> callback);
 
         @DELETE("/polls/{pollid}/poll_choices/{poll_choice_id}")
         void deletePollChoice(@Path("pollid") long poll_id, @Path("poll_choice_id") long poll_choice_id, Callback<Response> callback);
@@ -68,13 +69,13 @@ public class PollChoiceAPI extends BuildInterfaceAPI {
     public static void createPollChoice(long poll_id, String text, boolean is_correct, int position, CanvasCallback<PollChoiceResponse> callback) {
         if (APIHelpers.paramIsNull(callback, poll_id, text, is_correct)) { return; }
 
-        buildInterface(PollChoiceInterface.class, callback).createPollChoice(poll_id, text, is_correct, position, callback);
+        buildInterface(PollChoiceInterface.class, callback).createPollChoice(poll_id, text, is_correct, position, "", callback);
     }
 
     public static void updatePollChoice(long poll_id, long poll_choice_id, String text, boolean is_correct, int position, CanvasCallback<PollChoiceResponse> callback) {
         if (APIHelpers.paramIsNull(callback, poll_id, poll_choice_id, text, is_correct)) { return; }
 
-        buildInterface(PollChoiceInterface.class, callback).updatePollChoice(poll_id, poll_choice_id, text, is_correct, position, callback);
+        buildInterface(PollChoiceInterface.class, callback).updatePollChoice(poll_id, poll_choice_id, text, is_correct, position, "", callback);
     }
 
     public static void deletePollChoice(long poll_id, long poll_choice_id, CanvasCallback<Response> callback) {

--- a/src/main/java/com/instructure/canvasapi/api/PollSessionAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/PollSessionAPI.java
@@ -6,6 +6,7 @@ import com.instructure.canvasapi.utilities.CanvasCallback;
 
 import retrofit.Callback;
 import retrofit.client.Response;
+import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.GET;
 import retrofit.http.POST;
@@ -30,10 +31,10 @@ public class PollSessionAPI extends BuildInterfaceAPI {
         void getSinglePollSession(@Path("pollid") long poll_id, @Path("poll_session_id") long poll_session_id, Callback<PollSessionResponse> callback);
 
         @POST("/polls/{pollid}/poll_sessions")
-        void createPollSession(@Path("pollid") long poll_id, @Query("poll_sessions[][course_id]") long course_id, @Query("poll_sessions[][course_section_id]") long course_section_id, Callback<PollSessionResponse> callback);
+        void createPollSession(@Path("pollid") long poll_id, @Query("poll_sessions[][course_id]") long course_id, @Query("poll_sessions[][course_section_id]") long course_section_id, @Body String body, Callback<PollSessionResponse> callback);
 
         @PUT("/polls/{pollid}/poll_sessions/{poll_session_id}")
-        void updatePollSession(@Path("pollid") long poll_id, @Path("poll_session_id") long poll_session_id,  @Query("poll_sessions[][course_id]") long course_id, @Query("poll_sessions[][course_section_id]") long course_section_id, @Query("poll_sessions[][has_public_results]") boolean has_public_results, Callback<PollSessionResponse> callback);
+        void updatePollSession(@Path("pollid") long poll_id, @Path("poll_session_id") long poll_session_id,  @Query("poll_sessions[][course_id]") long course_id, @Query("poll_sessions[][course_section_id]") long course_section_id, @Query("poll_sessions[][has_public_results]") boolean has_public_results, @Body String body, Callback<PollSessionResponse> callback);
 
         @DELETE("/polls/{pollid}/poll_sessions/{poll_session_id}")
         void deletePollSession(@Path("pollid") long poll_id, @Path("poll_session_id") long poll_session_id, Callback<Response> callback);
@@ -80,13 +81,13 @@ public class PollSessionAPI extends BuildInterfaceAPI {
     public static void createPollSession(long poll_id, long course_id, long course_section_id, CanvasCallback<PollSessionResponse> callback) {
         if (APIHelpers.paramIsNull(callback, poll_id, course_id, course_section_id)) { return; }
 
-        buildInterface(PollSessionInterface.class, callback).createPollSession(poll_id, course_id, course_section_id, callback);
+        buildInterface(PollSessionInterface.class, callback).createPollSession(poll_id, course_id, course_section_id, "", callback);
     }
 
     public static void updatePollSession(long poll_id, long poll_session_id, long course_id, long course_section_id, boolean has_public_results, CanvasCallback<PollSessionResponse> callback) {
         if (APIHelpers.paramIsNull(callback, poll_id, poll_session_id, course_id, course_section_id, has_public_results)) { return; }
 
-        buildInterface(PollSessionInterface.class, callback).updatePollSession(poll_id, poll_session_id, course_id, course_section_id, has_public_results, callback);
+        buildInterface(PollSessionInterface.class, callback).updatePollSession(poll_id, poll_session_id, course_id, course_section_id, has_public_results, "", callback);
     }
 
     public static void deletePollSession(long poll_id, long poll_session_id, CanvasCallback<Response> callback) {

--- a/src/main/java/com/instructure/canvasapi/api/PollSubmissionAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/PollSubmissionAPI.java
@@ -5,6 +5,7 @@ import com.instructure.canvasapi.utilities.APIHelpers;
 import com.instructure.canvasapi.utilities.CanvasCallback;
 
 import retrofit.Callback;
+import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.POST;
 import retrofit.http.Path;
@@ -22,7 +23,7 @@ public class PollSubmissionAPI extends BuildInterfaceAPI {
         void getPollSubmission(@Path("pollid") long poll_id, @Path("poll_session_id") long poll_session_id, @Path("poll_submission_id") long poll_submission_id, Callback<PollSubmissionResponse> callback);
 
         @POST("/polls/{pollid}/poll_sessions/{poll_session_id}/poll_submissions/")
-        void createPollSubmission(@Path("pollid") long poll_id, @Path("poll_session_id") long poll_session_id, @Query("poll_submissions[][poll_choice_id]") long poll_choice_id, Callback<PollSubmissionResponse> callback);
+        void createPollSubmission(@Path("pollid") long poll_id, @Path("poll_session_id") long poll_session_id, @Query("poll_submissions[][poll_choice_id]") long poll_choice_id, @Body String body, Callback<PollSubmissionResponse> callback);
 
     }
 
@@ -40,7 +41,7 @@ public class PollSubmissionAPI extends BuildInterfaceAPI {
     public static void createPollSubmission(long poll_id, long poll_session_id, long poll_choice_id, CanvasCallback<PollSubmissionResponse> callback) {
         if (APIHelpers.paramIsNull(callback, poll_id, poll_session_id, poll_choice_id)) { return; }
 
-        buildInterface(PollSubmissionInterface.class, callback).createPollSubmission(poll_id, poll_session_id, poll_choice_id, callback);
+        buildInterface(PollSubmissionInterface.class, callback).createPollSubmission(poll_id, poll_session_id, poll_choice_id, "", callback);
     }
 
 }

--- a/src/main/java/com/instructure/canvasapi/api/QuizAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/QuizAPI.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 
 import retrofit.Callback;
 import retrofit.client.Response;
+import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.POST;
 import retrofit.http.PUT;
@@ -48,7 +49,7 @@ public class QuizAPI extends BuildInterfaceAPI {
         void getNextPageQuizQuestions(@Path(value = "next", encode = false) String nextURL, Callback<QuizQuestion[]> callback);
 
         @POST("/{context_id}/quizzes/{quizid}/submissions")
-        void startQuiz(@Path("context_id") long context_id, @Path("quizid") long quizid, Callback<Response> callback);
+        void startQuiz(@Path("context_id") long context_id, @Path("quizid") long quizid, @Body String body, Callback<Response> callback);
 
         @GET("/{context_id}/quizzes/{quizid}/submissions")
         void getFirstPageQuizSubmissions(@Path("context_id") long context_id, @Path("quizid") long quizid, Callback<QuizSubmissionResponse> callback);
@@ -63,28 +64,28 @@ public class QuizAPI extends BuildInterfaceAPI {
         void getNextPageSubmissionQuestions(@Path(value = "next", encode = false) String nextURL, Callback<QuizSubmissionQuestionResponse> callback);
 
         @POST("/quiz_submissions/{quiz_submission_id}/questions")
-        void postQuizQuestionMultiChoice(@Path("quiz_submission_id") long quizSubmissionId, @Query("attempt") int attempt, @Query("validation_token") String token, @Query("quiz_questions[][id]") long questionId, @Query("quiz_questions[][answer]") long answer, Callback<QuizSubmissionQuestionResponse> callback);
+        void postQuizQuestionMultiChoice(@Path("quiz_submission_id") long quizSubmissionId, @Query("attempt") int attempt, @Query("validation_token") String token, @Query("quiz_questions[][id]") long questionId, @Query("quiz_questions[][answer]") long answer, @Body String body, Callback<QuizSubmissionQuestionResponse> callback);
 
         @PUT("/quiz_submissions/{quiz_submission_id}/questions/{question_id}/flag")
-        void putFlagQuizQuestion(@Path("quiz_submission_id") long quizSubmissionId, @Path("question_id") long questionId, @Query("attempt") int attempt, @Query("validation_token") String token, CanvasCallback<Response> callback);
+        void putFlagQuizQuestion(@Path("quiz_submission_id") long quizSubmissionId, @Path("question_id") long questionId, @Query("attempt") int attempt, @Query("validation_token") String token, @Body String body, CanvasCallback<Response> callback);
 
         @PUT("/quiz_submissions/{quiz_submission_id}/questions/{question_id}/unflag")
-        void putUnflagQuizQuestion(@Path("quiz_submission_id") long quizSubmissionId, @Path("question_id") long questionId, @Query("attempt") int attempt, @Query("validation_token") String token, CanvasCallback<Response> callback);
+        void putUnflagQuizQuestion(@Path("quiz_submission_id") long quizSubmissionId, @Path("question_id") long questionId, @Query("attempt") int attempt, @Query("validation_token") String token, @Body String body, CanvasCallback<Response> callback);
 
         @POST("/quiz_submissions/{quiz_submission_id}/questions")
-        void postQuizQuestionEssay(@Path("quiz_submission_id") long quizSubmissionId, @Query("attempt") int attempt, @Query("validation_token") String token, @Query("quiz_questions[][id]") long questionId, @Query("quiz_questions[][answer]") String answer, Callback<QuizSubmissionQuestionResponse> callback);
+        void postQuizQuestionEssay(@Path("quiz_submission_id") long quizSubmissionId, @Query("attempt") int attempt, @Query("validation_token") String token, @Query("quiz_questions[][id]") long questionId, @Query("quiz_questions[][answer]") String answer, @Body String body, Callback<QuizSubmissionQuestionResponse> callback);
 
         @POST("/{context_id}/quizzes/{quiz_id}/submissions/{submission_id}/complete")
-        void postQuizSubmit(@Path("context_id") long context_id, @Path("quiz_id") long quizId, @Path("submission_id") long submissionId, @Query("attempt") int attempt, @Query("validation_token") String token, Callback<QuizSubmissionResponse> callback);
+        void postQuizSubmit(@Path("context_id") long context_id, @Path("quiz_id") long quizId, @Path("submission_id") long submissionId, @Query("attempt") int attempt, @Query("validation_token") String token, @Body String body, Callback<QuizSubmissionResponse> callback);
 
         @POST("/{context_id}/quizzes/{quiz_id}/submissions/{submission_id}/events")
-        void postQuizStartedEvent(@Path("context_id") long context_id, @Path("quiz_id") long quizId, @Path("submission_id") long submissionId, @Query("quiz_submission_events[][event_type]") String sessionStartedString, @Query("quiz_submission_events[][event_data][user_agent]") String userAgentString, CanvasCallback<Response> callback);
+        void postQuizStartedEvent(@Path("context_id") long context_id, @Path("quiz_id") long quizId, @Path("submission_id") long submissionId, @Query("quiz_submission_events[][event_type]") String sessionStartedString, @Query("quiz_submission_events[][event_data][user_agent]") String userAgentString, @Body String body, CanvasCallback<Response> callback);
 
         @GET("/{context_id}/quizzes/{quiz_id}/submissions/{submission_id}/time")
         void getQuizSubmissionTime(@Path("context_id") long context_id, @Path("quiz_id") long quizId, @Path("submission_id") long submissionId, CanvasCallback<QuizSubmissionTime> callback);
 
         @POST("/quiz_submissions/{quiz_submission_id}/questions{query_params}")
-        void postQuizQuestionMultiAnswers(@Path("quiz_submission_id") long quizSubmissionId,  @Path(value = "query_params", encode = false) String queryParams, Callback<QuizSubmissionQuestionResponse> callback);
+        void postQuizQuestionMultiAnswers(@Path("quiz_submission_id") long quizSubmissionId,  @Path(value = "query_params", encode = false) String queryParams, @Body String body, Callback<QuizSubmissionQuestionResponse> callback);
 
     }
 
@@ -139,7 +140,7 @@ public class QuizAPI extends BuildInterfaceAPI {
     public static void startQuiz(CanvasContext canvasContext, long quiz_id, CanvasCallback<Response> callback) {
         if (APIHelpers.paramIsNull(callback, canvasContext)) { return; }
 
-        buildInterface(QuizzesInterface.class, callback, canvasContext).startQuiz(canvasContext.getId(), quiz_id, callback);
+        buildInterface(QuizzesInterface.class, callback, canvasContext).startQuiz(canvasContext.getId(), quiz_id, "", callback);
     }
 
     public static void getFirstPageQuizSubmissions(CanvasContext canvasContext, long quiz_id, CanvasCallback<QuizSubmissionResponse> callback) {
@@ -173,16 +174,16 @@ public class QuizAPI extends BuildInterfaceAPI {
     public static void postQuizQuestionMultiChoice(QuizSubmission quizSubmission, long answerId, long questionId, CanvasCallback<QuizSubmissionQuestionResponse> callback){
         if (APIHelpers.paramIsNull(callback, quizSubmission, quizSubmission.getSubmissionId(), quizSubmission.getValidationToken())) { return; }
 
-        buildInterface(QuizzesInterface.class, callback, null).postQuizQuestionMultiChoice(quizSubmission.getId(), quizSubmission.getAttempt(), quizSubmission.getValidationToken(), questionId, answerId, callback);
+        buildInterface(QuizzesInterface.class, callback, null).postQuizQuestionMultiChoice(quizSubmission.getId(), quizSubmission.getAttempt(), quizSubmission.getValidationToken(), questionId, answerId, "", callback);
     }
 
     public static void putFlagQuizQuestion(QuizSubmission quizSubmission, long quizQuestionId, boolean shouldFlag, CanvasCallback<Response> callback) {
         if (APIHelpers.paramIsNull(callback, quizSubmission, quizSubmission.getSubmissionId(), quizSubmission.getValidationToken())) { return; }
 
         if(shouldFlag) {
-            buildInterface(QuizzesInterface.class, callback, null).putFlagQuizQuestion(quizSubmission.getId(), quizQuestionId, quizSubmission.getAttempt(), quizSubmission.getValidationToken(), callback);
+            buildInterface(QuizzesInterface.class, callback, null).putFlagQuizQuestion(quizSubmission.getId(), quizQuestionId, quizSubmission.getAttempt(), quizSubmission.getValidationToken(), "", callback);
         } else {
-            buildInterface(QuizzesInterface.class, callback, null).putUnflagQuizQuestion(quizSubmission.getId(), quizQuestionId, quizSubmission.getAttempt(), quizSubmission.getValidationToken(), callback);
+            buildInterface(QuizzesInterface.class, callback, null).putUnflagQuizQuestion(quizSubmission.getId(), quizQuestionId, quizSubmission.getAttempt(), quizSubmission.getValidationToken(), "", callback);
 
         }
     }
@@ -190,19 +191,19 @@ public class QuizAPI extends BuildInterfaceAPI {
     public static void postQuizQuestionEssay(QuizSubmission quizSubmission, String answer, long questionId, CanvasCallback<QuizSubmissionQuestionResponse> callback){
         if (APIHelpers.paramIsNull(callback, quizSubmission, quizSubmission.getSubmissionId(), quizSubmission.getValidationToken())) { return; }
 
-        buildInterface(QuizzesInterface.class, callback, null).postQuizQuestionEssay(quizSubmission.getId(), quizSubmission.getAttempt(), quizSubmission.getValidationToken(), questionId, answer, callback);
+        buildInterface(QuizzesInterface.class, callback, null).postQuizQuestionEssay(quizSubmission.getId(), quizSubmission.getAttempt(), quizSubmission.getValidationToken(), questionId, answer, "", callback);
     }
 
     public static void postQuizSubmit(CanvasContext canvasContext, QuizSubmission quizSubmission, CanvasCallback<QuizSubmissionResponse> callback) {
         if (APIHelpers.paramIsNull(canvasContext, callback, quizSubmission, quizSubmission.getSubmissionId(), quizSubmission.getValidationToken())) { return; }
 
-        buildInterface(QuizzesInterface.class, callback, canvasContext).postQuizSubmit(canvasContext.getId(), quizSubmission.getQuizId(), quizSubmission.getId(), quizSubmission.getAttempt(), quizSubmission.getValidationToken(), callback);
+        buildInterface(QuizzesInterface.class, callback, canvasContext).postQuizSubmit(canvasContext.getId(), quizSubmission.getQuizId(), quizSubmission.getId(), quizSubmission.getAttempt(), quizSubmission.getValidationToken(), "", callback);
     }
 
     public static void postQuizStartedEvent(CanvasContext canvasContext, QuizSubmission quizSubmission, String userAgentString, CanvasCallback<Response> callback) {
         if (APIHelpers.paramIsNull(canvasContext, callback, quizSubmission, quizSubmission.getSubmissionId())) { return; }
 
-        buildInterface(QuizzesInterface.class, callback, canvasContext).postQuizStartedEvent(canvasContext.getId(), quizSubmission.getQuizId(), quizSubmission.getId(), QUIZ_SUBMISSION_SESSION_STARTED, userAgentString, callback);
+        buildInterface(QuizzesInterface.class, callback, canvasContext).postQuizStartedEvent(canvasContext.getId(), quizSubmission.getQuizId(), quizSubmission.getId(), QUIZ_SUBMISSION_SESSION_STARTED, userAgentString, "", callback);
     }
 
     public static void getQuizSubmissionTime(CanvasContext canvasContext, QuizSubmission quizSubmission, CanvasCallback<QuizSubmissionTime> callback) {
@@ -214,7 +215,7 @@ public class QuizAPI extends BuildInterfaceAPI {
         if (APIHelpers.paramIsNull(callback, quizSubmission, quizSubmission.getSubmissionId(), quizSubmission.getValidationToken())) { return; }
 
         //we don't to append the per_page parameter because we're building the query parameters ourselves, so use the different interface
-        buildInterface(QuizzesInterface.class, callback, null, false).postQuizQuestionMultiAnswers(quizSubmission.getId(), buildMultiAnswerList(quizSubmission.getAttempt(), quizSubmission.getValidationToken(), questionId, answers), callback);
+        buildInterface(QuizzesInterface.class, callback, null, false).postQuizQuestionMultiAnswers(quizSubmission.getId(), buildMultiAnswerList(quizSubmission.getAttempt(), quizSubmission.getValidationToken(), questionId, answers), "", callback);
     }
 
     private static String buildMultiAnswerList(int attempt, String validationToken, long questionId, ArrayList<Integer> answers) {

--- a/src/main/java/com/instructure/canvasapi/api/SectionAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/SectionAPI.java
@@ -10,6 +10,7 @@ import com.instructure.canvasapi.utilities.CanvasCallback;
 import java.util.Date;
 
 import retrofit.Callback;
+import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.PUT;
 import retrofit.http.Path;
@@ -17,17 +18,20 @@ import retrofit.http.Query;
 
 /**
  *
- * Copyright (c) 2014 Instructure. All rights reserved.
+ * Copyright (c) 2015 Instructure. All rights reserved.
  */
 public class SectionAPI extends BuildInterfaceAPI {
 
     interface SectionsInterface {
 
         @PUT("{courseid}/sections/{sectionid}")
-        void updateSection(@Path("courseid") long courseID, @Path("sectionid") long sectionID,
-                @Query("course_section[name]") String name,
-                @Query("course_section[start_at]") String startAt, @Query("course_section[end_at]") String endAt,
-                CanvasCallback<Section> callback
+        void updateSection(@Path("courseid") long courseID,
+                           @Path("sectionid") long sectionID,
+                           @Query("course_section[name]") String name,
+                           @Query("course_section[start_at]") String startAt,
+                           @Query("course_section[end_at]") String endAt,
+                           @Body String body,
+                           CanvasCallback<Section> callback
         );
 
         @GET("/{courseid}/sections")
@@ -96,7 +100,7 @@ public class SectionAPI extends BuildInterfaceAPI {
         String startAtString = APIHelpers.dateToString(newStartAt);
         String endAtString = APIHelpers.dateToString(newEndAt);
 
-        buildInterface(SectionsInterface.class, callback,course).updateSection(course.getId(), section.getId(), newSectionName, startAtString, endAtString, callback);
+        buildInterface(SectionsInterface.class, callback,course).updateSection(course.getId(), section.getId(), newSectionName, startAtString, endAtString, "", callback);
 
     }
 

--- a/src/main/java/com/instructure/canvasapi/api/SubmissionAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/SubmissionAPI.java
@@ -65,39 +65,39 @@ public class SubmissionAPI extends BuildInterfaceAPI {
         void getNextPageSubmissions(@Path(value = "next", encode = false) String nextURL, Callback<Submission[]> callback);
 
         @PUT("/{context_id}/assignments/{assignmentID}/submissions/{userID}")
-        void postSubmissionComment(@Path("context_id") long context_id, @Path("assignmentID") long assignmentID, @Path("userID") long userID, @Query("comment[text_comment]") String comment, Callback<Submission> callback);
+        void postSubmissionComment(@Path("context_id") long context_id, @Path("assignmentID") long assignmentID, @Path("userID") long userID, @Query("comment[text_comment]") String comment, @Body String body, Callback<Submission> callback);
 
         @PUT("/{context_id}/assignments/{assignmentID}/submissions/{userID}")
         void postMediaSubmissionComment(@Path("context_id") long context_id, @Path("assignmentID") long assignmentID, @Path("userID") long userID, @Query("comment[media_comment_id]") String media_id,
-                                        @Query("comment[media_comment_type]") String commentType, Callback<Submission> callback);
+                                        @Query("comment[media_comment_type]") String commentType, @Body String body, Callback<Submission> callback);
         @POST("/{context_id}/assignments/{assignmentID}/submissions")
-        void postTextSubmission(@Path("context_id") long context_id, @Path("assignmentID") long assignmentID, @Query("submission[submission_type]") String submissionType, @Query("submission[body]") String text, Callback<Submission> callback);
+        void postTextSubmission(@Path("context_id") long context_id, @Path("assignmentID") long assignmentID, @Query("submission[submission_type]") String submissionType, @Query("submission[body]") String text, @Body String body, Callback<Submission> callback);
 
         @POST("/{context_id}/assignments/{assignmentID}/submissions")
-        void postURLSubmission(@Path("context_id") long context_id, @Path("assignmentID") long assignmentID, @Query("submission[submission_type]") String submissionType, @Query("submission[url]") String url, Callback<Submission> callback);
+        void postURLSubmission(@Path("context_id") long context_id, @Path("assignmentID") long assignmentID, @Query("submission[submission_type]") String submissionType, @Query("submission[url]") String url, @Body String body, Callback<Submission> callback);
 
         @POST("/{context_id}/assignments/{assignmentID}/submissions")
         void postMediaSubmission(@Path("context_id") long context_id, @Path("assignmentID") long assignmentID, @Query("submission[submission_type]") String submissionType,
-                                 @Query("submission[media_comment_id]") String kalturaId,@Query("submission[media_comment_type]") String mediaType, CanvasCallback<Submission> callback);
+                                 @Query("submission[media_comment_id]") String kalturaId,@Query("submission[media_comment_type]") String mediaType, @Body String body, CanvasCallback<Submission> callback);
 
         @GET("/{path}")
         void getLTIFromAuthenticationURL(@Path(value = "path", encode = false) String url, Callback<LTITool> callback);
 
         @PUT("/{context_id}/assignments/{assignmentID}/submissions/{userID}")
-        void postSubmissionRubricAssessmentMap(@Path("context_id") long context_id, @Path("assignmentID") long assignmentID, @Path("userID") long userID, @QueryMap Map<String, String> rubricAssessment, @Query("submission[posted_grade]") String assignmentScore, Callback<Submission> callback);
+        void postSubmissionRubricAssessmentMap(@Path("context_id") long context_id, @Path("assignmentID") long assignmentID, @Path("userID") long userID, @QueryMap Map<String, String> rubricAssessment, @Query("submission[posted_grade]") String assignmentScore, @Body String body, Callback<Submission> callback);
 
         /////////////////////////////////////////////////////////////////////////////
         // Synchronous
         /////////////////////////////////////////////////////////////////////////////
         @POST("/courses/{courseId}/assignments/{assignmentId}/submissions/self/files")
-        FileUploadParams getFileUploadParams(@Path("courseId") long courseId, @Path("assignmentId") long assignmentId, @Query("size") long size, @Query("name") String fileName, @Query("content_type") String content_type);
+        FileUploadParams getFileUploadParams(@Path("courseId") long courseId, @Path("assignmentId") long assignmentId, @Query("size") long size, @Query("name") String fileName, @Query("content_type") String content_type, @Body String body);
 
         @Multipart
         @POST("/")
-        Attachment uploadCourseFile(@PartMap LinkedHashMap<String, String> params, @Part("file") TypedFile file);
+        Attachment uploadCourseFile(@PartMap LinkedHashMap<String, String> params, @Part("file") TypedFile file, @Body String body);
 
         @POST("/courses/{courseId}/assignments/{assignmentID}/submissions")
-        Submission postSubmissionAttachments(@Path("courseId") long courseId, @Path("assignmentID") long assignmentID, @Query("submission[submission_type]") String submissionType, @Query("submission[file_ids][]") ArrayList<String> attachments);
+        Submission postSubmissionAttachments(@Path("courseId") long courseId, @Path("assignmentID") long assignmentID, @Query("submission[submission_type]") String submissionType, @Query("submission[file_ids][]") ArrayList<String> attachments, @Body String body);
     }
 
     /////////////////////////////////////////////////////////////////////////
@@ -199,30 +199,30 @@ public class SubmissionAPI extends BuildInterfaceAPI {
     public static void postSubmissionComment(CanvasContext canvasContext, long assignmentID, long userID, String comment, final CanvasCallback<Submission> callback) {
         if (APIHelpers.paramIsNull(callback, canvasContext)) { return; }
 
-        buildInterface(SubmissionsInterface.class, callback, canvasContext).postSubmissionComment(canvasContext.getId(), assignmentID, userID, comment, callback);
+        buildInterface(SubmissionsInterface.class, callback, canvasContext).postSubmissionComment(canvasContext.getId(), assignmentID, userID, comment, "", callback);
     }
     public static void postMediaSubmissionComment(CanvasContext canvasContext, long assignmentID, long userID, String kalturaMediaId, String mediaType, final CanvasCallback<Submission> callback) {
         if (APIHelpers.paramIsNull(callback, canvasContext)) { return; }
 
-        buildInterface(SubmissionsInterface.class, callback, canvasContext).postMediaSubmissionComment(canvasContext.getId(), assignmentID, userID, kalturaMediaId, mediaType, callback);
+        buildInterface(SubmissionsInterface.class, callback, canvasContext).postMediaSubmissionComment(canvasContext.getId(), assignmentID, userID, kalturaMediaId, mediaType, "", callback);
     }
 
     public static void postTextSubmission(CanvasContext canvasContext, long assignmentID, String submissionType, String text, final CanvasCallback<Submission> callback) {
         if (APIHelpers.paramIsNull(callback, submissionType, text, canvasContext)) { return; }
 
-        buildInterface(SubmissionsInterface.class, callback, canvasContext).postTextSubmission(canvasContext.getId(), assignmentID, submissionType, text, callback);
+        buildInterface(SubmissionsInterface.class, callback, canvasContext).postTextSubmission(canvasContext.getId(), assignmentID, submissionType, text, "", callback);
     }
 
     public static void postURLSubmission(CanvasContext canvasContext, long assignmentID, String submissionType, String url, final CanvasCallback<Submission> callback) {
         if (APIHelpers.paramIsNull(callback, submissionType, url, canvasContext)) { return; }
 
-        buildInterface(SubmissionsInterface.class, callback, canvasContext).postURLSubmission(canvasContext.getId(), assignmentID, submissionType, url, callback);
+        buildInterface(SubmissionsInterface.class, callback, canvasContext).postURLSubmission(canvasContext.getId(), assignmentID, submissionType, url, "", callback);
     }
 
     public static void postMediaSubmission(CanvasContext canvasContext, long assignmentID, String submissionType, String kalturaId, String mediaType, final  CanvasCallback<Submission> callback){
         if (APIHelpers.paramIsNull(callback, submissionType, kalturaId, canvasContext)) { return; }
 
-        buildInterface(SubmissionsInterface.class, callback, canvasContext).postMediaSubmission(canvasContext.getId(), assignmentID, submissionType, kalturaId, mediaType, callback);
+        buildInterface(SubmissionsInterface.class, callback, canvasContext).postMediaSubmission(canvasContext.getId(), assignmentID, submissionType, kalturaId, mediaType, "", callback);
     }
 
     public static void getLTIFromAuthenticationURL(String url, final CanvasCallback<LTITool> callback) {
@@ -271,7 +271,7 @@ public class SubmissionAPI extends BuildInterfaceAPI {
     public static void postSubmissionRubricAssessmentMap(CanvasContext canvasContext, RubricAssessment rubricAssessment, String assignmentScore, long assignmentId, long userId, CanvasCallback<Submission> callback){
         if (APIHelpers.paramIsNull(canvasContext, rubricAssessment, callback)){return;}
 
-        buildInterface(SubmissionsInterface.class, callback, canvasContext).postSubmissionRubricAssessmentMap(canvasContext.getId(), assignmentId, userId, generateRubricAssessmentQueryMap(rubricAssessment), assignmentScore, callback);
+        buildInterface(SubmissionsInterface.class, callback, canvasContext).postSubmissionRubricAssessmentMap(canvasContext.getId(), assignmentId, userId, generateRubricAssessmentQueryMap(rubricAssessment), assignmentScore, "", callback);
     }
 
     private static Map<String, String> generateRubricAssessmentQueryMap(RubricAssessment rubricAssessment){
@@ -289,14 +289,14 @@ public class SubmissionAPI extends BuildInterfaceAPI {
     // Synchronous
     /////////////////////////////////////////////////////////////////////////////
     public static FileUploadParams getFileUploadParams(Context context, long courseId, long assignmentId, String fileName, long size, String contentType){
-        return buildInterface(SubmissionsInterface.class, context).getFileUploadParams(courseId, assignmentId, size, fileName, contentType);
+        return buildInterface(SubmissionsInterface.class, context).getFileUploadParams(courseId, assignmentId, size, fileName, contentType, "");
     }
 
     public static Attachment uploadAssignmentSubmission(String uploadUrl, LinkedHashMap<String,String> uploadParams, String mimeType, File file){
-        return buildUploadInterface(SubmissionsInterface.class, uploadUrl).uploadCourseFile(uploadParams, new TypedFile(mimeType, file));
+        return buildUploadInterface(SubmissionsInterface.class, uploadUrl).uploadCourseFile(uploadParams, new TypedFile(mimeType, file), "");
     }
 
     public static Submission postSubmissionAttachments(Context context, long courseId, long assignmentId, ArrayList<String> attachments){
-        return buildInterface(SubmissionsInterface.class, context).postSubmissionAttachments(courseId, assignmentId, "online_upload",attachments);
+        return buildInterface(SubmissionsInterface.class, context).postSubmissionAttachments(courseId, assignmentId, "online_upload", attachments, "");
     }
 }

--- a/src/main/java/com/instructure/canvasapi/api/TabAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/TabAPI.java
@@ -5,6 +5,7 @@ import com.instructure.canvasapi.model.Tab;
 import com.instructure.canvasapi.utilities.APIHelpers;
 import com.instructure.canvasapi.utilities.CanvasCallback;
 
+import retrofit.http.Body;
 import retrofit.http.GET;
 import retrofit.http.PUT;
 import retrofit.http.Path;
@@ -19,7 +20,7 @@ public class TabAPI extends BuildInterfaceAPI {
     interface TabsInterface {
 
         @PUT("{/context_id}/tabs{tab_id}")
-        void updateTab(@Query("hidden") Integer hidden, @Query("position") Integer oneBasedIndexPosition, CanvasCallback<Tab> callback);
+        void updateTab(@Query("hidden") Integer hidden, @Query("position") Integer oneBasedIndexPosition, @Body String body, CanvasCallback<Tab> callback);
 
         @GET("/{context_id}/tabs?include[]=external")
         void getTabs(@Path("context_id") long context_id, CanvasCallback<Tab[]> callback);
@@ -51,7 +52,7 @@ public class TabAPI extends BuildInterfaceAPI {
 
         Integer hiddenInteger = newIsHidden == null ? null : APIHelpers.booleanToInt(newIsHidden);
 
-        buildInterface(TabsInterface.class, callback,canvasContext).updateTab(hiddenInteger, newOneBasedIndexPosition, callback);
+        buildInterface(TabsInterface.class, callback,canvasContext).updateTab(hiddenInteger, newOneBasedIndexPosition, "", callback);
     }
 
 }

--- a/src/main/java/com/instructure/canvasapi/api/UserAPI.java
+++ b/src/main/java/com/instructure/canvasapi/api/UserAPI.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.util.LinkedHashMap;
 
 import retrofit.Callback;
+import retrofit.http.Body;
 import retrofit.http.DELETE;
 import retrofit.http.GET;
 import retrofit.http.Multipart;
@@ -32,7 +33,7 @@ import retrofit.mime.TypedFile;
 
 /**
  *
- * Copyright (c) 2014 Instructure. All rights reserved.
+ * Copyright (c) 2015 Instructure. All rights reserved.
  */
 public class UserAPI extends BuildInterfaceAPI {
 
@@ -51,7 +52,7 @@ public class UserAPI extends BuildInterfaceAPI {
         void getSelfWithPermission(CanvasCallback<User> callback);
 
         @PUT("/users/self")
-        void updateShortName(@Query("user[short_name]") String shortName, Callback<User> callback);
+        void updateShortName(@Query("user[short_name]") String shortName, @Body String body, Callback<User> callback);
 
         @GET("/users/{userid}/profile")
         void getUserById(@Path("userid")long userId, Callback<User> userCallback);
@@ -69,30 +70,30 @@ public class UserAPI extends BuildInterfaceAPI {
         void getNextPagePeopleList(@Path(value = "next", encode = false) String nextURL, Callback<User[]> callback);
 
         @POST("/users/self/file")
-        void uploadUserFileURL( @Query("url") String fileURL, @Query("name") String fileName, @Query("size") long size, @Query("content_type") String content_type, @Query("parent_folder_path") String parentFolderPath, Callback<String> callback);
+        void uploadUserFileURL( @Query("url") String fileURL, @Query("name") String fileName, @Query("size") long size, @Query("content_type") String content_type, @Query("parent_folder_path") String parentFolderPath, @Body String body, Callback<String> callback);
 
         @POST("/users/self/files")
-        FileUploadParams getFileUploadParams( @Query("size") long size, @Query("name") String fileName, @Query("content_type") String content_type, @Query("parent_folder_id") Long parentFolderId);
+        FileUploadParams getFileUploadParams( @Query("size") long size, @Query("name") String fileName, @Query("content_type") String content_type, @Query("parent_folder_id") Long parentFolderId, @Body String body);
 
         @POST("/users/self/files")
-        FileUploadParams getFileUploadParams( @Query("size") long size, @Query("name") String fileName, @Query("content_type") String content_type, @Query("parent_folder_path") String parentFolderPath);
+        FileUploadParams getFileUploadParams( @Query("size") long size, @Query("name") String fileName, @Query("content_type") String content_type, @Query("parent_folder_path") String parentFolderPath, @Body String body);
 
         @Multipart
         @POST("/")
-        Attachment uploadUserFile(@PartMap LinkedHashMap<String, String> params, @Part("file") TypedFile file);
+        Attachment uploadUserFile(@PartMap LinkedHashMap<String, String> params, @Part("file") TypedFile file, @Body String body);
 
         //Colors
         @GET("/users/self/colors")
         void getColors(CanvasCallback<CanvasColor> callback);
 
         @PUT("/users/self/colors/{context_id}")
-        void setColor(@Path("context_id") String context_id, @Query(value = "hexcode", encodeValue = false) String color, CanvasCallback<CanvasColor> callback);
+        void setColor(@Path("context_id") String context_id, @Query(value = "hexcode", encodeValue = false) String color, @Body String body, CanvasCallback<CanvasColor> callback);
 
         @POST("/accounts/{account_id}/self_registration")
-        void createSelfRegistrationUser(@Path("account_id") long account_id, @Query("user[name]") String userName, @Query("pseudonym[unique_id]") String emailAddress, @Query("user[terms_of_use]") int acceptsTerms, Callback<User> callback);
+        void createSelfRegistrationUser(@Path("account_id") long account_id, @Query("user[name]") String userName, @Query("pseudonym[unique_id]") String emailAddress, @Query("user[terms_of_use]") int acceptsTerms, @Body String body, Callback<User> callback);
 
         @POST("/users/self/observees")
-        void addObserveeWithToken(@Query("access_token") String token, CanvasCallback<User> callback);
+        void addObserveeWithToken(@Query("access_token") String token, @Body String body, CanvasCallback<User> callback);
 
         @GET("/users/self/observees?include[]=avatar_url")
         void getObservees(CanvasCallback<User[]> callback);
@@ -147,7 +148,7 @@ public class UserAPI extends BuildInterfaceAPI {
     public static void updateShortName(String shortName, CanvasCallback<User> callback) {
         if (APIHelpers.paramIsNull(callback, shortName)) { return; }
 
-        buildInterface(UsersInterface.class, callback, null).updateShortName(shortName, callback);
+        buildInterface(UsersInterface.class, callback, null).updateShortName(shortName, "", callback);
     }
 
     public static void getUserById(long userId, CanvasCallback<User> userCanvasCallback){
@@ -279,19 +280,19 @@ public class UserAPI extends BuildInterfaceAPI {
             hexColor = hexColor.replaceAll("#", "");
         }
 
-        buildInterface(UsersInterface.class, context, false).setColor(context_id, hexColor, callback);
+        buildInterface(UsersInterface.class, context, false).setColor(context_id, hexColor, "", callback);
     }
 
     public static void createSelfRegistrationUser(long accountId, String userName, String emailAddress, CanvasCallback<User> callback) {
         if (APIHelpers.paramIsNull(userName, emailAddress, callback)) { return; }
 
-        buildInterface(UsersInterface.class, callback, false).createSelfRegistrationUser(accountId, userName, emailAddress, 1, callback);
+        buildInterface(UsersInterface.class, callback, false).createSelfRegistrationUser(accountId, userName, emailAddress, 1, "", callback);
     }
 
     public static void addObserveeByToken(String token, CanvasCallback<User> callback) {
         if(APIHelpers.paramIsNull(token, callback)) { return; }
 
-        buildInterface(UsersInterface.class, callback, false).addObserveeWithToken(token, callback);
+        buildInterface(UsersInterface.class, callback, false).addObserveeWithToken(token, "", callback);
     }
 
     public static void getObservees(CanvasCallback<User[]> callback) {
@@ -310,15 +311,15 @@ public class UserAPI extends BuildInterfaceAPI {
     // Synchronous Calls
     /////////////////////////////////////////////////////////////////////////
     public static FileUploadParams getFileUploadParams(Context context, String fileName, long size, String contentType, Long parentFolderId){
-        return buildInterface(UsersInterface.class, context).getFileUploadParams(size, fileName, contentType, parentFolderId);
+        return buildInterface(UsersInterface.class, context).getFileUploadParams(size, fileName, contentType, parentFolderId, "");
     }
 
     public static FileUploadParams getFileUploadParams(Context context, String fileName, long size, String contentType, String parentFolderPath){
-        return buildInterface(UsersInterface.class, context).getFileUploadParams(size, fileName, contentType, parentFolderPath);
+        return buildInterface(UsersInterface.class, context).getFileUploadParams(size, fileName, contentType, parentFolderPath, "");
     }
 
     public static Attachment uploadUserFile(String uploadUrl, LinkedHashMap<String,String> uploadParams, String mimeType, File file){
-        return buildUploadInterface(UsersInterface.class, uploadUrl).uploadUserFile(uploadParams, new TypedFile(mimeType, file));
+        return buildUploadInterface(UsersInterface.class, uploadUrl).uploadUserFile(uploadParams, new TypedFile(mimeType, file), "");
     }
 
     /////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We cannot revet OKHttp because we need the changes for caching. Adding empty body is the work-around. 