### PR TITLE
Added setter method for field 'bio' for User model

### DIFF
--- a/src/main/java/com/instructure/canvasapi/model/User.java
+++ b/src/main/java/com/instructure/canvasapi/model/User.java
@@ -112,6 +112,10 @@ public class User extends CanvasContext{
     }
 
     public String getBio() { return bio; }
+    
+    public void setBio(String bio){
+        this.bio = bio;
+    }
 
     // User Permissions - defaults to false, returned with UserAPI.getSelfWithPermissions()
     public boolean canUpdateAvatar(){


### PR DESCRIPTION
Setter method for `bio` is not available. I have added it. Also, try using 'AutoValue' extensions. Using that you will have to just declare the fields and all the setter/getter methods, Parceable implementation, and equals method implementation will be created automatically at runtime. 

A very detailed talk by Jake Wharton is here: http://jakewharton.com/presentation/2016-03-10-android-spring-cleaning/